### PR TITLE
fix: include browse result presentation helpers

### DIFF
--- a/src/features/browse/browseResultPresentation.js
+++ b/src/features/browse/browseResultPresentation.js
@@ -1,0 +1,39 @@
+import {
+  buildLocationParts,
+  formatBrowseResultName,
+} from "./browseResults";
+import { buildLifeDatesSummary } from "./sidebarPresentation";
+
+const RESULT_METADATA_SEPARATOR = " \u2022 ";
+
+export const buildBrowseResultCardPresentation = ({
+  result = {},
+  scopedSectionLabel = "",
+  scopedTourLabel = "",
+  tourStyleName = "",
+} = {}) => {
+  const locationSummary = buildLocationParts(result)
+    .filter((part) => !(scopedSectionLabel && part === scopedSectionLabel))
+    .join(", ");
+  const shouldShowSectionChip = Boolean(result.Section)
+    && `Section ${result.Section}` !== scopedSectionLabel;
+  const metadataSummary = [
+    shouldShowSectionChip ? `Section ${result.Section}` : "",
+    result.Lot ? `Lot ${result.Lot}` : "",
+    result.Tier ? `Tier ${result.Tier}` : "",
+  ].filter(Boolean).join(RESULT_METADATA_SEPARATOR);
+  const resultTourLabel = result.tourName || tourStyleName || "";
+  const tourChipLabel = Boolean(resultTourLabel)
+    && !(scopedTourLabel && resultTourLabel === scopedTourLabel)
+    ? resultTourLabel
+    : "";
+
+  return {
+    displayName: formatBrowseResultName(result),
+    lifeSummary: buildLifeDatesSummary(result),
+    locationSummary,
+    metadataSummary,
+    secondarySummary: locationSummary ? "" : (result.secondaryText || ""),
+    tourChipLabel,
+  };
+};

--- a/test/browseResultPresentation.test.js
+++ b/test/browseResultPresentation.test.js
@@ -1,0 +1,60 @@
+import { buildBrowseResultCardPresentation } from "../src/features/browse/browseResultPresentation";
+
+describe("browse result presentation helpers", () => {
+  test("builds scoped section result card copy without repeating the active section", () => {
+    expect(buildBrowseResultCardPresentation({
+      result: {
+        displayName: "Ada Lovelace",
+        Section: "49",
+        Lot: "12",
+        Tier: "A",
+        Grave: "5",
+        Birth: "1815",
+        Death: "1852",
+        secondaryText: "Fallback copy",
+      },
+      scopedSectionLabel: "Section 49",
+    })).toEqual({
+      displayName: "Ada Lovelace",
+      lifeSummary: "Born 1815 \u2022 Died 1852",
+      locationSummary: "Lot 12, Tier A, Grave 5",
+      metadataSummary: "Lot 12 \u2022 Tier A",
+      secondarySummary: "",
+      tourChipLabel: "",
+    });
+  });
+
+  test("falls back to secondary text and suppresses the active tour chip", () => {
+    expect(buildBrowseResultCardPresentation({
+      result: {
+        displayName: "Tour Marker",
+        secondaryText: "Memorial path entrance",
+        tourName: "Founders Tour",
+      },
+      scopedTourLabel: "Founders Tour",
+      tourStyleName: "Profile Tour Label",
+    })).toEqual({
+      displayName: "Tour Marker",
+      lifeSummary: "",
+      locationSummary: "",
+      metadataSummary: "",
+      secondarySummary: "Memorial path entrance",
+      tourChipLabel: "",
+    });
+  });
+
+  test("uses tour metadata as the chip label outside the active tour scope", () => {
+    expect(buildBrowseResultCardPresentation({
+      result: {
+        First_Name: "Anna",
+        Last_Name: "Tracy",
+        tourKey: "notable-women",
+      },
+      scopedTourLabel: "Civil War Tour",
+      tourStyleName: "Notable Women",
+    })).toMatchObject({
+      displayName: "Anna Tracy",
+      tourChipLabel: "Notable Women",
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n\n- Adds the browse result presentation helper module that BurialSidebar imports.\n- Adds focused Bun coverage for scoped browse-result card copy.\n\n## Validation\n\n- bun run check\n\n## Release impact\n\n- Patch-level repository hygiene fix; no user-facing behavior change intended.