### PR TITLE
fix: extract selected place detail presentation

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -37,9 +37,10 @@ import {
 } from "./features/browse/browseResults";
 import { buildBrowseResultCardPresentation } from "./features/browse/browseResultPresentation";
 import {
+  DEFAULT_SELECTED_PLACE_DETAIL_ROW_LIMIT,
+  buildSelectedPlaceDetailPresentation,
   buildSelectedSummaryPresentation,
   buildSelectedPlaceInitials,
-  getSelectedPlaceDetailRows,
   getSelectedPlaceTypeLabel,
   hasFieldPacketContent,
 } from "./features/browse/selectedRecordPresentation";
@@ -912,9 +913,11 @@ function SelectionLeadCard({
   const lifeSummary = buildLifeDatesSummary(burial);
   const popupView = useMemo(() => buildPopupViewModel(burial), [burial]);
   const popupKey = burial?.id || popupView.heading;
-  const allDetailRows = getSelectedPlaceDetailRows(popupView.rows);
-  const detailLinkUrl = cleanRecordValue(popupView.biographyLink || popupView.imageLinkUrl);
-  const hasDetailsContent = allDetailRows.length > 0 || Boolean(detailLinkUrl);
+  const detailPresentation = buildSelectedPlaceDetailPresentation({
+    detailLinkUrl: popupView.biographyLink || popupView.imageLinkUrl,
+    isExpanded: true,
+    rows: popupView.rows,
+  });
   const [mediaUrl, setMediaUrl] = useState(() => popupView.imageUrl || "");
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
@@ -1051,7 +1054,7 @@ function SelectionLeadCard({
           </Box>
         </Box>
       </ButtonBase>
-      {hasDetailsContent && (
+      {detailPresentation.hasDetailsContent && (
         <>
           <button
             type="button"
@@ -1062,9 +1065,9 @@ function SelectionLeadCard({
           </button>
           {isDetailsOpen && (
             <Box sx={{ mt: 0.85 }}>
-              {allDetailRows.length > 0 && (
+              {detailPresentation.allDetailRows.length > 0 && (
                 <Box component="dl" className="left-sidebar__selected-place-facts">
-                  {allDetailRows.map(({ label, value }) => (
+                  {detailPresentation.allDetailRows.map(({ label, value }) => (
                     <Box key={`${popupKey}-lead-${label}`} className="left-sidebar__selected-place-fact">
                       <dt>{label}</dt>
                       <dd>{value}</dd>
@@ -1072,11 +1075,11 @@ function SelectionLeadCard({
                   ))}
                 </Box>
               )}
-              {detailLinkUrl && (
+              {detailPresentation.detailLinkUrl && (
                 <Box sx={{ mt: 0.85 }}>
                   <a
                     className="popup-card__action popup-card__action--secondary"
-                    href={detailLinkUrl}
+                    href={detailPresentation.detailLinkUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -1099,8 +1102,6 @@ function SelectionLeadCard({
   );
 }
 
-const COMPACT_DETAIL_ROWS_VISIBLE = 4;
-
 function SelectedPlaceCard({
   burial,
   isRouteActive,
@@ -1116,10 +1117,14 @@ function SelectedPlaceCard({
   const locationSummary = buildLocationSummary(burial);
   const lifeSummary = buildLifeDatesSummary(burial);
   const placeTypeLabel = getSelectedPlaceTypeLabel(burial);
-  const allDetailRows = getSelectedPlaceDetailRows(popupView.rows);
-  const detailLinkUrl = cleanRecordValue(popupView.biographyLink || popupView.imageLinkUrl);
   const [mediaUrl, setMediaUrl] = useState(() => popupView.imageUrl || "");
   const [isDetailExpanded, setIsDetailExpanded] = useState(false);
+  const detailPresentation = buildSelectedPlaceDetailPresentation({
+    detailLinkUrl: popupView.biographyLink || popupView.imageLinkUrl,
+    isExpanded: isDetailExpanded,
+    rows: popupView.rows,
+    visibleRowLimit: DEFAULT_SELECTED_PLACE_DETAIL_ROW_LIMIT,
+  });
 
   useEffect(() => {
     setMediaUrl(popupView.imageUrl || "");
@@ -1138,9 +1143,6 @@ function SelectedPlaceCard({
   }, [popupView.imageFallbackUrl]);
 
   const hasCompactMeta = Boolean(isRouteActive || tourStyle);
-  const visibleRows = isDetailExpanded ? allDetailRows : allDetailRows.slice(0, COMPACT_DETAIL_ROWS_VISIBLE);
-  const hiddenCount = allDetailRows.length - COMPACT_DETAIL_ROWS_VISIBLE;
-  const hasMoreRows = hiddenCount > 0;
   const actionGroup = (
     <Box className="popup-card__actions left-sidebar__selected-place-card-actions left-sidebar__selected-place-card-actions--inline">
       <button
@@ -1157,10 +1159,10 @@ function SelectedPlaceCard({
       >
         {isRouteActive ? "Stop Navigation" : "Navigate"}
       </button>
-      {detailLinkUrl && (
+      {detailPresentation.detailLinkUrl && (
         <a
           className="popup-card__action popup-card__action--secondary"
-          href={detailLinkUrl}
+          href={detailPresentation.detailLinkUrl}
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -1231,9 +1233,9 @@ function SelectedPlaceCard({
             stackDescription={stackList.description}
           />
         )}
-        {visibleRows.length > 0 && (
+        {detailPresentation.visibleRows.length > 0 && (
           <Box component="dl" className="left-sidebar__selected-place-facts">
-            {visibleRows.map(({ label, value }) => (
+            {detailPresentation.visibleRows.map(({ label, value }) => (
               <Box key={`${popupKey}-compact-${label}`} className="left-sidebar__selected-place-fact">
                 <dt>{label}</dt>
                 <dd>{value}</dd>
@@ -1241,7 +1243,7 @@ function SelectedPlaceCard({
             ))}
           </Box>
         )}
-        {hasMoreRows && (
+        {detailPresentation.hasMoreRows && (
           <button
             type="button"
             className="popup-card__action popup-card__action--ghost left-sidebar__detail-toggle"
@@ -1249,7 +1251,7 @@ function SelectedPlaceCard({
           >
             {isDetailExpanded
               ? "Fewer details"
-              : `More details (${hiddenCount})`}
+              : `More details (${detailPresentation.hiddenCount})`}
           </button>
         )}
         {hasCompactMeta && (

--- a/src/features/browse/selectedRecordPresentation.js
+++ b/src/features/browse/selectedRecordPresentation.js
@@ -1,5 +1,6 @@
 import { cleanRecordValue } from "../map/mapRecordPresentation";
 
+export const DEFAULT_SELECTED_PLACE_DETAIL_ROW_LIMIT = 4;
 const DETAIL_ROW_EXCLUDE_LABELS = ["Location", "Born", "Died"];
 const SINGLE_SELECTION_PANEL_TITLE = "Selected grave";
 const STACK_SELECTION_PANEL_TITLE = "Graves at this spot";
@@ -80,6 +81,30 @@ export const getSelectedPlaceTypeLabel = (record = {}) => {
 export const getSelectedPlaceDetailRows = (rows = []) => (
   rows.filter(({ label }) => !DETAIL_ROW_EXCLUDE_LABELS.includes(label))
 );
+
+export const buildSelectedPlaceDetailPresentation = ({
+  detailLinkUrl = "",
+  isExpanded = false,
+  rows = [],
+  visibleRowLimit = DEFAULT_SELECTED_PLACE_DETAIL_ROW_LIMIT,
+} = {}) => {
+  const allDetailRows = getSelectedPlaceDetailRows(rows);
+  const normalizedVisibleRowLimit = Number.isFinite(Number(visibleRowLimit)) && Number(visibleRowLimit) > 0
+    ? Number(visibleRowLimit)
+    : DEFAULT_SELECTED_PLACE_DETAIL_ROW_LIMIT;
+  const hiddenCount = Math.max(0, allDetailRows.length - normalizedVisibleRowLimit);
+
+  return {
+    allDetailRows,
+    detailLinkUrl: cleanRecordValue(detailLinkUrl),
+    hasDetailsContent: allDetailRows.length > 0 || Boolean(cleanRecordValue(detailLinkUrl)),
+    hasMoreRows: hiddenCount > 0,
+    hiddenCount,
+    visibleRows: isExpanded
+      ? allDetailRows
+      : allDetailRows.slice(0, normalizedVisibleRowLimit),
+  };
+};
 
 export const hasFieldPacketContent = (fieldPacket) => {
   if (!fieldPacket) {

--- a/test/selectedRecordPresentation.test.js
+++ b/test/selectedRecordPresentation.test.js
@@ -1,4 +1,5 @@
 import {
+  buildSelectedPlaceDetailPresentation,
   buildSelectedSummaryPresentation,
   buildSelectedPlaceInitials,
   getSelectedPlaceDetailRows,
@@ -7,6 +8,79 @@ import {
 } from "../src/features/browse/selectedRecordPresentation";
 
 describe("selected record presentation helpers", () => {
+  test("builds compact selected-place detail presentation with hidden row count", () => {
+    const rows = [
+      { label: "Location", value: "Section 10" },
+      { label: "Born", value: "1815" },
+      { label: "Died", value: "1852" },
+      { label: "Section", value: "10" },
+      { label: "Lot", value: "4" },
+      { label: "Tier", value: "A" },
+      { label: "Grave", value: "8" },
+      { label: "Notes", value: "Founder" },
+    ];
+
+    expect(buildSelectedPlaceDetailPresentation({
+      detailLinkUrl: " https://example.test/details ",
+      isExpanded: false,
+      rows,
+      visibleRowLimit: 3,
+    })).toEqual({
+      allDetailRows: [
+        { label: "Section", value: "10" },
+        { label: "Lot", value: "4" },
+        { label: "Tier", value: "A" },
+        { label: "Grave", value: "8" },
+        { label: "Notes", value: "Founder" },
+      ],
+      detailLinkUrl: "https://example.test/details",
+      hasDetailsContent: true,
+      hasMoreRows: true,
+      hiddenCount: 2,
+      visibleRows: [
+        { label: "Section", value: "10" },
+        { label: "Lot", value: "4" },
+        { label: "Tier", value: "A" },
+      ],
+    });
+  });
+
+  test("returns every selected-place detail row when expanded", () => {
+    const rows = [
+      { label: "Section", value: "10" },
+      { label: "Lot", value: "4" },
+      { label: "Tier", value: "A" },
+      { label: "Grave", value: "8" },
+    ];
+
+    const presentation = buildSelectedPlaceDetailPresentation({
+      isExpanded: true,
+      rows,
+      visibleRowLimit: 2,
+    });
+
+    expect(presentation.visibleRows).toEqual(rows);
+    expect(presentation.hiddenCount).toBe(2);
+    expect(presentation.hasMoreRows).toBe(true);
+  });
+
+  test("treats a details link as content even when no detail rows remain", () => {
+    expect(buildSelectedPlaceDetailPresentation({
+      detailLinkUrl: "https://example.test/profile",
+      rows: [
+        { label: "Location", value: "Section 10" },
+        { label: "Born", value: "1815" },
+      ],
+    })).toMatchObject({
+      allDetailRows: [],
+      detailLinkUrl: "https://example.test/profile",
+      hasDetailsContent: true,
+      hasMoreRows: false,
+      hiddenCount: 0,
+      visibleRows: [],
+    });
+  });
+
   test("returns no selected-summary presentation when there is no lead record", () => {
     expect(buildSelectedSummaryPresentation({
       activeBurialId: "missing",


### PR DESCRIPTION
## Summary\n\n- Moves selected-place detail row/link presentation into a tested browse helper.\n- Keeps BurialSidebar focused on composition instead of row-count/detail-link rules.\n\n## Validation\n\n- bun run check\n\n## Release impact\n\n- No version bump needed; behavior-preserving sidebar cleanup.