### PR TITLE
fix: extract sidebar presentation helpers

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -22,11 +22,11 @@ import "react-spring-bottom-sheet/dist/style.css";
 import { APP_PROFILE } from "./features/fab/profile";
 import BrowseWorkspacePanel, { BrowseSearchField } from "./features/browse/BrowseWorkspacePanel";
 import {
+  buildBrowseResultsPanelPresentation,
   buildLifeDatesSummary,
   buildBrowseEmptyActionSpecs,
   buildBrowseScopeChips,
   buildSearchShellNotices,
-  getBrowseEmptyState,
   getSearchPlaceholder,
 } from "./features/browse/sidebarPresentation";
 import {
@@ -459,16 +459,6 @@ function BrowseResultsPanel({
   scopeChips = EMPTY_PACKET_RECORDS,
   tourStyles,
 }) {
-  const emptyMessage = getBrowseEmptyState({
-    browseSource,
-    isBurialDataLoading,
-    isCurrentTourLoading,
-    minBrowseQueryLength: MIN_BROWSE_QUERY_LENGTH,
-    query,
-    sectionFilter,
-    selectedTour,
-    tourLabel: TOUR_LABEL,
-  });
   const selectedBurialIds = useMemo(
     () => new Set(selectedBurials.map((item) => item.id)),
     [selectedBurials]
@@ -476,10 +466,7 @@ function BrowseResultsPanel({
   const onBrowseResultSelectRef = useRef(onBrowseResultSelect);
   const onHoverBurialChangeRef = useRef(onHoverBurialChange);
   const selectedBurialCount = selectedBurials.length;
-  const displayedResults = browseResults;
-  const displayedResultCount = displayedResults.length;
   const [visibleCount, setVisibleCount] = useState(batchSize);
-  const shouldPageResults = browseSource === "all";
 
   onBrowseResultSelectRef.current = onBrowseResultSelect;
   onHoverBurialChangeRef.current = onHoverBurialChange;
@@ -506,35 +493,48 @@ function BrowseResultsPanel({
     selectedTour,
   ]);
 
-  const visibleResults = useMemo(
-    () => (
-      shouldPageResults
-        ? displayedResults.slice(0, visibleCount)
-        : displayedResults
-    ),
-    [displayedResults, shouldPageResults, visibleCount]
+  const panelPresentation = useMemo(
+    () => buildBrowseResultsPanelPresentation({
+      batchSize,
+      browseResults,
+      browseSource,
+      isBurialDataLoading,
+      isCurrentTourLoading,
+      minBrowseQueryLength: MIN_BROWSE_QUERY_LENGTH,
+      query,
+      scopeChips,
+      sectionFilter,
+      selectedTour,
+      tourLabel: TOUR_LABEL,
+      visibleCount,
+    }),
+    [
+      batchSize,
+      browseResults,
+      browseSource,
+      isBurialDataLoading,
+      isCurrentTourLoading,
+      query,
+      scopeChips,
+      sectionFilter,
+      selectedTour,
+      visibleCount,
+    ]
   );
-  const hasMoreResults = shouldPageResults && displayedResultCount > visibleCount;
-  const canShowFewerResults = shouldPageResults && visibleCount > batchSize;
-  const resultSummary = `${displayedResultCount.toLocaleString()} result${displayedResultCount === 1 ? "" : "s"}`;
-  const trimmedQuery = query.trim();
-  const scopedSectionLabel = browseSource === "section" && sectionFilter
-    ? `Section ${sectionFilter}`
-    : "";
-  const scopedTourLabel = browseSource === "tour" ? selectedTour : "";
-  const shouldRenderEmptyState = displayedResultCount === 0;
-  const hasScopeChips = scopeChips.length > 0;
-  const isScopedBrowse = browseSource === "section" || browseSource === "tour";
-  const resultsEyebrow = isScopedBrowse
-    ? ""
-    : trimmedQuery
-      ? "Search"
-      : "Browse";
-  const resultsTitle = isScopedBrowse
-    ? "Results"
-    : trimmedQuery
-      ? "Search results"
-      : "Burials";
+  const {
+    canShowFewerResults,
+    displayedResultCount,
+    emptyMessage,
+    hasMoreResults,
+    hasScopeChips,
+    resultSummaryLabel,
+    resultsEyebrow,
+    resultsTitle,
+    scopedSectionLabel,
+    scopedTourLabel,
+    shouldRenderEmptyState,
+    visibleResults,
+  } = panelPresentation;
 
   return (
     <Box
@@ -608,9 +608,7 @@ function BrowseResultsPanel({
           variant="body2"
           sx={{ color: "var(--muted-text)" }}
         >
-          {browseSource === "all" && trimmedQuery
-            ? `${resultSummary} for "${trimmedQuery}".`
-            : resultSummary}
+          {resultSummaryLabel}
         </Typography>
       )}
 

--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -44,7 +44,7 @@ import {
   getSelectedPlaceTypeLabel,
   hasFieldPacketContent,
 } from "./features/browse/selectedRecordPresentation";
-import { buildSharedSelectionPresentation } from "./features/fieldPackets";
+import { buildFieldPacketPanelPresentation } from "./features/fieldPackets";
 import { PopupCardStackList } from "./features/map/popupCardContent";
 import { buildPopupViewModel, cleanRecordValue } from "./features/map/mapRecordPresentation";
 import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
@@ -1529,27 +1529,48 @@ function FieldPacketPanel({
   sharedLinkLandingState,
   showIosInstallHint,
 }) {
-  const packetRecords = fieldPacket?.selectedRecords || EMPTY_PACKET_RECORDS;
-  const hasPacket = packetRecords.length > 0;
-  const hasSelectedBurials = selectedBurials.length > 0;
-  const canUseNativeShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
-  const canInstallApp = Boolean(installPromptEvent) && !isInstalled;
-  const canOpenIosAppStore = Boolean(iosAppStoreUrl) && !isInstalled;
-  const displayRecordCount = hasPacket ? packetRecords.length : selectedBurials.length;
-  const fieldPacketPresentation = useMemo(
-    () => buildSharedSelectionPresentation(fieldPacket || {}),
-    [fieldPacket]
+  const hasNativeShare = typeof navigator !== "undefined" && typeof navigator.share === "function";
+  const panelPresentation = useMemo(
+    () => buildFieldPacketPanelPresentation({
+      fieldPacket,
+      fieldPacketNotice,
+      hasNativeShare,
+      installPromptEvent,
+      iosAppStoreUrl,
+      isInstalled,
+      selectedBurials,
+    }),
+    [
+      fieldPacket,
+      fieldPacketNotice,
+      hasNativeShare,
+      installPromptEvent,
+      iosAppStoreUrl,
+      isInstalled,
+      selectedBurials,
+    ]
   );
-  const noticeColor = fieldPacketNotice?.tone === "success"
-    ? "var(--accent)"
-    : fieldPacketNotice?.tone === "warning"
-      ? "#9a6c19"
-      : "var(--muted-text)";
+  const {
+    canCopyOrShare,
+    canInstallApp,
+    canOpenIosAppStore,
+    canUseNativeShare,
+    displayRecordCountLabel,
+    emptyStateMessage,
+    hasMapContext,
+    hasPacket,
+    hasSectionFilter,
+    hasSelectedTour,
+    noticeColor,
+    panelPadding,
+    savedDetailsHint,
+    sharedSelectionPresentation,
+  } = panelPresentation;
 
   return (
     <Box
       className="left-sidebar__panel left-sidebar__panel--field-packet left-sidebar__panel--surface"
-      sx={{ ...panelSurfaceStyles, p: hasPacket ? 1.75 : 1.55 }}
+      sx={{ ...panelSurfaceStyles, p: panelPadding }}
     >
       <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 1.25, mb: 1 }}>
         <Box sx={{ minWidth: 0 }}>
@@ -1560,7 +1581,7 @@ function FieldPacketPanel({
         </Box>
         <Chip
           size="small"
-          label={`${displayRecordCount} record${displayRecordCount === 1 ? "" : "s"}`}
+          label={displayRecordCountLabel}
         />
       </Box>
 
@@ -1584,7 +1605,7 @@ function FieldPacketPanel({
             Opened from a shared link
           </Typography>
           <Typography variant="body2" sx={{ mt: 0.5, color: "var(--muted-text)" }}>
-            {fieldPacketPresentation.description}
+            {sharedSelectionPresentation.description}
           </Typography>
           {(canInstallApp || canOpenIosAppStore) && (
             <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: 1.15 }}>
@@ -1638,13 +1659,13 @@ function FieldPacketPanel({
             Anyone with the link can see this title, message, and saved view.
           </Typography>
           <Box className="left-sidebar__chip-row" sx={{ mt: 1.25 }}>
-            {fieldPacket?.sectionFilter && (
-              <Chip size="small" variant="outlined" label={`Section ${fieldPacket.sectionFilter}`} />
+            {hasSectionFilter && (
+              <Chip size="small" variant="outlined" label={sharedSelectionPresentation.sectionLabel} />
             )}
-            {fieldPacket?.selectedTour && (
-              <Chip size="small" variant="outlined" label={fieldPacket.selectedTour} />
+            {hasSelectedTour && (
+              <Chip size="small" variant="outlined" label={sharedSelectionPresentation.selectedTour} />
             )}
-            {fieldPacket?.mapBounds && (
+            {hasMapContext && (
               <Chip size="small" variant="outlined" label="Map context saved" />
             )}
           </Box>
@@ -1656,16 +1677,12 @@ function FieldPacketPanel({
               color: "var(--muted-text)",
             }}
           >
-            {hasSelectedBurials
-              ? "Copying or sharing updates the link to the current selection and map view."
-              : "This link restores the saved selection and map view."}
+            {savedDetailsHint}
           </Typography>
         </>
       ) : (
         <Typography variant="body2" sx={{ color: "var(--muted-text)" }}>
-          {hasSelectedBurials
-            ? `${selectedBurials.length} selected record${selectedBurials.length === 1 ? "" : "s"} ready to share.`
-            : "Select one or more records to create a share link."}
+          {emptyStateMessage}
         </Typography>
       )}
 
@@ -1680,7 +1697,7 @@ function FieldPacketPanel({
           size="small"
           variant="contained"
           onClick={onCopyFieldPacketLink}
-          disabled={!hasPacket && !hasSelectedBurials}
+          disabled={!canCopyOrShare}
         >
           Copy share link
         </Button>
@@ -1689,7 +1706,7 @@ function FieldPacketPanel({
             size="small"
             variant="outlined"
             onClick={onShareFieldPacket}
-            disabled={!hasPacket && !hasSelectedBurials}
+            disabled={!canCopyOrShare}
           >
             Share link
           </Button>

--- a/src/features/browse/sidebarPresentation.js
+++ b/src/features/browse/sidebarPresentation.js
@@ -243,6 +243,85 @@ export const getBrowseEmptyState = ({
   return `No matches for "${query.trim()}". Check spelling or try a section number.`;
 };
 
+export const buildBrowseResultsPanelPresentation = ({
+  batchSize = 10,
+  browseResults = [],
+  browseSource = "all",
+  isBurialDataLoading = false,
+  isCurrentTourLoading = false,
+  minBrowseQueryLength = 2,
+  query = "",
+  scopeChips = [],
+  sectionFilter = "",
+  selectedTour = "",
+  tourLabel = "Tour",
+  visibleCount = batchSize,
+} = {}) => {
+  const displayedResults = Array.isArray(browseResults) ? browseResults : [];
+  const displayedResultCount = displayedResults.length;
+  const normalizedBatchSize = Number.isFinite(Number(batchSize)) && Number(batchSize) > 0
+    ? Number(batchSize)
+    : displayedResultCount;
+  const normalizedVisibleCount = Number.isFinite(Number(visibleCount)) && Number(visibleCount) > 0
+    ? Number(visibleCount)
+    : normalizedBatchSize;
+  const shouldPageResults = browseSource === "all";
+  const visibleResults = shouldPageResults
+    ? displayedResults.slice(0, normalizedVisibleCount)
+    : displayedResults;
+  const hasMoreResults = shouldPageResults && displayedResultCount > normalizedVisibleCount;
+  const canShowFewerResults = shouldPageResults && normalizedVisibleCount > normalizedBatchSize;
+  const resultSummary = `${displayedResultCount.toLocaleString()} result${displayedResultCount === 1 ? "" : "s"}`;
+  const trimmedQuery = String(query || "").trim();
+  const scopedSectionLabel = browseSource === "section" && sectionFilter
+    ? `Section ${sectionFilter}`
+    : "";
+  const scopedTourLabel = browseSource === "tour" ? selectedTour : "";
+  const shouldRenderEmptyState = displayedResultCount === 0;
+  const isScopedBrowse = browseSource === "section" || browseSource === "tour";
+  const resultsEyebrow = isScopedBrowse
+    ? ""
+    : trimmedQuery
+      ? "Search"
+      : "Browse";
+
+  return {
+    canShowFewerResults,
+    displayedResultCount,
+    emptyMessage: shouldRenderEmptyState
+      ? getBrowseEmptyState({
+        browseSource,
+        isBurialDataLoading,
+        isCurrentTourLoading,
+        minBrowseQueryLength,
+        query: trimmedQuery,
+        sectionFilter,
+        selectedTour,
+        tourLabel,
+      })
+      : "",
+    hasMoreResults,
+    hasScopeChips: Array.isArray(scopeChips) && scopeChips.length > 0,
+    isScopedBrowse,
+    resultSummary,
+    resultSummaryLabel: browseSource === "all" && trimmedQuery
+      ? `${resultSummary} for "${trimmedQuery}".`
+      : resultSummary,
+    resultsEyebrow,
+    resultsTitle: isScopedBrowse
+      ? "Results"
+      : trimmedQuery
+        ? "Search results"
+        : "Burials",
+    scopedSectionLabel,
+    scopedTourLabel,
+    shouldPageResults,
+    shouldRenderEmptyState,
+    trimmedQuery,
+    visibleResults,
+  };
+};
+
 export const buildBrowseScopeChips = ({
   browseSource,
   filterType,

--- a/src/features/fieldPackets.js
+++ b/src/features/fieldPackets.js
@@ -402,3 +402,55 @@ export const buildSharedSelectionPresentation = (packet = {}) => {
     recordCount,
   };
 };
+
+export const buildFieldPacketPanelPresentation = ({
+  fieldPacket = null,
+  fieldPacketNotice = null,
+  hasNativeShare = false,
+  installPromptEvent = null,
+  iosAppStoreUrl = "",
+  isInstalled = false,
+  selectedBurials = [],
+} = {}) => {
+  const packetRecords = Array.isArray(fieldPacket?.selectedRecords)
+    ? fieldPacket.selectedRecords
+    : [];
+  const selectedBurialCount = Array.isArray(selectedBurials) ? selectedBurials.length : 0;
+  const hasPacket = packetRecords.length > 0;
+  const hasSelectedBurials = selectedBurialCount > 0;
+  const displayRecordCount = hasPacket ? packetRecords.length : selectedBurialCount;
+  const noticeTone = cleanValue(fieldPacketNotice?.tone);
+  const noticeColor = noticeTone === "success"
+    ? "var(--accent)"
+    : noticeTone === "warning"
+      ? "#9a6c19"
+      : "var(--muted-text)";
+
+  return {
+    canCopyOrShare: hasPacket || hasSelectedBurials,
+    canInstallApp: Boolean(installPromptEvent) && !isInstalled,
+    canOpenIosAppStore: Boolean(cleanValue(iosAppStoreUrl)) && !isInstalled,
+    canUseNativeShare: Boolean(hasNativeShare),
+    displayRecordCount,
+    displayRecordCountLabel: `${displayRecordCount} record${displayRecordCount === 1 ? "" : "s"}`,
+    emptyStateMessage: hasSelectedBurials
+      ? `${selectedBurialCount} selected record${selectedBurialCount === 1 ? "" : "s"} ready to share.`
+      : "Select one or more records to create a share link.",
+    hasMapContext: Boolean(fieldPacket?.mapBounds),
+    hasPacket,
+    hasSectionFilter: Boolean(cleanValue(fieldPacket?.sectionFilter)),
+    hasSelectedBurials,
+    hasSelectedTour: Boolean(cleanValue(fieldPacket?.selectedTour)),
+    noticeColor,
+    packetRecords,
+    panelPadding: hasPacket ? 1.75 : 1.55,
+    savedDetailsHint: hasPacket
+      ? (
+        hasSelectedBurials
+          ? "Copying or sharing updates the link to the current selection and map view."
+          : "This link restores the saved selection and map view."
+      )
+      : "",
+    sharedSelectionPresentation: buildSharedSelectionPresentation(fieldPacket || {}),
+  };
+};

--- a/test/browseSidebarPresentation.test.js
+++ b/test/browseSidebarPresentation.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildBrowseEmptyActionSpecs,
+  buildBrowseResultsPanelPresentation,
   buildBrowseScopeChips,
   buildLifeDatesSummary,
   buildSearchShellNotices,
@@ -219,6 +220,117 @@ describe("browse sidebar presentation helpers", () => {
         variant: "text",
       },
     ]);
+  });
+
+  test("builds global search result panel presentation with pagination metadata", () => {
+    const browseResults = [
+      { id: "grave-1" },
+      { id: "grave-2" },
+      { id: "grave-3" },
+    ];
+
+    expect(buildBrowseResultsPanelPresentation({
+      batchSize: 2,
+      browseResults,
+      browseSource: "all",
+      isBurialDataLoading: false,
+      isCurrentTourLoading: false,
+      query: "  Ada  ",
+      scopeChips: [{ key: "markers", label: "Markers visible" }],
+      sectionFilter: "",
+      selectedTour: "",
+      visibleCount: 2,
+    })).toEqual({
+      canShowFewerResults: false,
+      displayedResultCount: 3,
+      emptyMessage: "",
+      hasMoreResults: true,
+      hasScopeChips: true,
+      isScopedBrowse: false,
+      resultSummary: "3 results",
+      resultSummaryLabel: "3 results for \"Ada\".",
+      resultsEyebrow: "Search",
+      resultsTitle: "Search results",
+      scopedSectionLabel: "",
+      scopedTourLabel: "",
+      shouldPageResults: true,
+      shouldRenderEmptyState: false,
+      trimmedQuery: "Ada",
+      visibleResults: [
+        { id: "grave-1" },
+        { id: "grave-2" },
+      ],
+    });
+  });
+
+  test("keeps scoped browse results unpaged with scoped labels", () => {
+    const browseResults = [
+      { id: "tour-1" },
+      { id: "tour-2" },
+    ];
+
+    expect(buildBrowseResultsPanelPresentation({
+      batchSize: 1,
+      browseResults,
+      browseSource: "tour",
+      isBurialDataLoading: false,
+      isCurrentTourLoading: false,
+      query: "",
+      sectionFilter: "12",
+      selectedTour: "Notables Tour 2020",
+      visibleCount: 1,
+    })).toMatchObject({
+      canShowFewerResults: false,
+      displayedResultCount: 2,
+      hasMoreResults: false,
+      isScopedBrowse: true,
+      resultSummaryLabel: "2 results",
+      resultsEyebrow: "",
+      resultsTitle: "Results",
+      scopedSectionLabel: "",
+      scopedTourLabel: "Notables Tour 2020",
+      shouldPageResults: false,
+      visibleResults: browseResults,
+    });
+  });
+
+  test("builds browse result panel empty-state metadata", () => {
+    expect(buildBrowseResultsPanelPresentation({
+      batchSize: 10,
+      browseResults: [],
+      browseSource: "section",
+      isBurialDataLoading: false,
+      isCurrentTourLoading: false,
+      query: "Smith",
+      sectionFilter: "8",
+      selectedTour: "",
+      visibleCount: 10,
+    })).toMatchObject({
+      displayedResultCount: 0,
+      emptyMessage: "No results in Section 8 for \"Smith\".",
+      hasMoreResults: false,
+      resultSummaryLabel: "0 results",
+      resultsEyebrow: "",
+      resultsTitle: "Results",
+      scopedSectionLabel: "Section 8",
+      shouldRenderEmptyState: true,
+      visibleResults: [],
+    });
+  });
+
+  test("uses the configured tour label in browse result panel empty states", () => {
+    expect(buildBrowseResultsPanelPresentation({
+      browseResults: [],
+      browseSource: "tour",
+      isBurialDataLoading: false,
+      isCurrentTourLoading: false,
+      query: "",
+      selectedTour: "",
+      tourLabel: "Route",
+    })).toMatchObject({
+      emptyMessage: "Choose a route above.",
+      shouldRenderEmptyState: true,
+    });
   });
 
   test("builds a compact life-dates summary when dates exist", () => {

--- a/test/fieldPackets.test.js
+++ b/test/fieldPackets.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildFieldPacketPanelPresentation,
   buildSharedSelectionPresentation,
   buildFieldPacketShareUrl,
   buildFieldPacketState,
@@ -164,6 +165,105 @@ describe("fieldPackets", () => {
       sectionLabel: "Section 99",
       selectedTour: "",
       recordCount: 2,
+    });
+  });
+
+  test("builds saved field-packet panel presentation from packet content", () => {
+    const presentation = buildFieldPacketPanelPresentation({
+      fieldPacket: {
+        name: "Section 99 check",
+        note: "Verify the Tracy marker before the tour.",
+        selectedRecords,
+        sectionFilter: "99",
+        mapBounds: [
+          [42.70, -73.74],
+          [42.71, -73.73],
+        ],
+      },
+      fieldPacketNotice: {
+        tone: "warning",
+        message: "Link copied from an older selection.",
+      },
+      hasNativeShare: true,
+      installPromptEvent: { prompt: () => {} },
+      iosAppStoreUrl: "https://apps.example.test/fab",
+      isInstalled: false,
+      selectedBurials: [selectedRecords[0]],
+    });
+
+    expect(presentation).toMatchObject({
+      canCopyOrShare: true,
+      canInstallApp: true,
+      canOpenIosAppStore: true,
+      canUseNativeShare: true,
+      displayRecordCount: 2,
+      displayRecordCountLabel: "2 records",
+      hasMapContext: true,
+      hasPacket: true,
+      hasSelectedBurials: true,
+      hasSectionFilter: true,
+      hasSelectedTour: false,
+      noticeColor: "#9a6c19",
+      packetRecords: selectedRecords,
+      panelPadding: 1.75,
+      savedDetailsHint: "Copying or sharing updates the link to the current selection and map view.",
+    });
+    expect(presentation.sharedSelectionPresentation).toMatchObject({
+      title: "Section 99 check",
+      description: "Verify the Tracy marker before the tour.",
+      recordCount: 2,
+    });
+  });
+
+  test("builds draft field-packet panel presentation from current selections", () => {
+    expect(buildFieldPacketPanelPresentation({
+      fieldPacket: null,
+      fieldPacketNotice: {
+        tone: "success",
+        message: "Ready to copy.",
+      },
+      hasNativeShare: false,
+      installPromptEvent: null,
+      iosAppStoreUrl: "https://apps.example.test/fab",
+      isInstalled: true,
+      selectedBurials: [selectedRecords[0]],
+    })).toMatchObject({
+      canCopyOrShare: true,
+      canInstallApp: false,
+      canOpenIosAppStore: false,
+      canUseNativeShare: false,
+      displayRecordCount: 1,
+      displayRecordCountLabel: "1 record",
+      emptyStateMessage: "1 selected record ready to share.",
+      hasMapContext: false,
+      hasPacket: false,
+      hasSelectedBurials: true,
+      hasSectionFilter: false,
+      hasSelectedTour: false,
+      noticeColor: "var(--accent)",
+      panelPadding: 1.55,
+      savedDetailsHint: "",
+    });
+  });
+
+  test("builds empty field-packet panel presentation when nothing can be shared", () => {
+    expect(buildFieldPacketPanelPresentation({
+      fieldPacket: {},
+      fieldPacketNotice: {
+        tone: "neutral",
+        message: "No selection.",
+      },
+      hasNativeShare: true,
+      selectedBurials: [],
+    })).toMatchObject({
+      canCopyOrShare: false,
+      displayRecordCount: 0,
+      displayRecordCountLabel: "0 records",
+      emptyStateMessage: "Select one or more records to create a share link.",
+      hasPacket: false,
+      hasSelectedBurials: false,
+      noticeColor: "var(--muted-text)",
+      packetRecords: [],
     });
   });
 


### PR DESCRIPTION
## Summary
- extract field packet panel presentation state into field-packet helpers
- wire the sidebar share-link panel to the helper-backed presentation model
- extract browse result panel pagination, labels, and empty-state metadata into tested browse presentation helpers

## Validation
- bun run check