### PR TITLE
fix: extract mobile sheet reveal intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -50,6 +50,7 @@ import { buildPopupViewModel, cleanRecordValue } from "./features/map/mapRecordP
 import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
 import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
+  buildMobileSheetRevealIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
 } from "./features/browse/sidebarState";
@@ -1928,55 +1929,43 @@ function BurialSidebar({
   }, [isMobile, resolvedMobileSheetState]);
 
   useEffect(() => {
-    const currentSelectionSignature = selectedBurials.map((record) => record.id).sort().join("|");
     const previousActiveBurialId = previousActiveBurialIdRef.current;
     const previousSectionFilter = previousSectionFilterRef.current;
     const previousSelectedTour = previousSelectedTourRef.current;
     const previousSelectionSignature = previousSelectionSignatureRef.current;
+    const revealIntent = buildMobileSheetRevealIntent({
+      activeBurialId,
+      isMobile,
+      previousActiveBurialId,
+      previousSectionFilter,
+      previousSelectedTour,
+      previousSelectionSignature,
+      resolvedMobileSheetState,
+      sectionFilter,
+      selectedBurials,
+      selectedTour,
+    });
 
     previousActiveBurialIdRef.current = activeBurialId;
     previousSectionFilterRef.current = sectionFilter;
     previousSelectedTourRef.current = selectedTour;
-    previousSelectionSignatureRef.current = currentSelectionSignature;
+    previousSelectionSignatureRef.current = revealIntent.currentSelectionSignature;
 
     if (!isMobile) {
       return;
     }
 
-    const didSelectionChange = Boolean(currentSelectionSignature)
-      && currentSelectionSignature !== previousSelectionSignature;
-    const didActiveBurialChange = Boolean(activeBurialId)
-      && activeBurialId !== previousActiveBurialId;
-    const didSectionChange = Boolean(sectionFilter)
-      && sectionFilter !== previousSectionFilter;
-    const didTourChange = Boolean(selectedTour)
-      && selectedTour !== previousSelectedTour;
-    const shouldRevealSelectedRecord = selectedBurials.length > 0
-      && (didSelectionChange || didActiveBurialChange);
-    const shouldRevealBrowseContext = selectedBurials.length === 0
-      && (didSectionChange || didTourChange);
-
-    if (!shouldRevealSelectedRecord && !shouldRevealBrowseContext) {
+    if (!revealIntent.shouldRevealSelectedRecord && !revealIntent.shouldRevealBrowseContext) {
       return;
     }
 
     // Mobile keeps the map usable by default, then reveals the drawer when a
     // user action creates a result or selection worth inspecting.
-    if (
-      shouldRevealSelectedRecord
-      && resolvedMobileSheetState === MOBILE_SHEET_STATES.COLLAPSED
-    ) {
+    if (revealIntent.shouldExpandMobileSheet) {
       expandMobileSheet();
     }
 
-    if (
-      shouldRevealBrowseContext
-      && resolvedMobileSheetState !== MOBILE_SHEET_STATES.FULL
-    ) {
-      expandMobileSheet();
-    }
-
-    if (didSelectionChange || shouldRevealBrowseContext) {
+    if (revealIntent.shouldScrollMobileSheetToTop) {
       scrollMobileSheetToTop("auto");
     }
   }, [

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,60 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildMobileSheetRevealIntent = ({
+  activeBurialId = "",
+  isMobile = false,
+  previousActiveBurialId = "",
+  previousSectionFilter = "",
+  previousSelectedTour = "",
+  previousSelectionSignature = "",
+  resolvedMobileSheetState = MOBILE_SHEET_STATES.PEEK,
+  sectionFilter = "",
+  selectedBurials = [],
+  selectedTour = "",
+} = {}) => {
+  const currentSelectionSignature = selectedBurials
+    .map((record) => record.id)
+    .sort()
+    .join("|");
+  const didSelectionChange = Boolean(currentSelectionSignature)
+    && currentSelectionSignature !== previousSelectionSignature;
+  const didActiveBurialChange = Boolean(activeBurialId)
+    && activeBurialId !== previousActiveBurialId;
+  const didSectionChange = Boolean(sectionFilter)
+    && sectionFilter !== previousSectionFilter;
+  const didTourChange = Boolean(selectedTour)
+    && selectedTour !== previousSelectedTour;
+  const shouldRevealSelectedRecord = Boolean(isMobile)
+    && selectedBurials.length > 0
+    && (didSelectionChange || didActiveBurialChange);
+  const shouldRevealBrowseContext = Boolean(isMobile)
+    && selectedBurials.length === 0
+    && (didSectionChange || didTourChange);
+
+  return {
+    currentSelectionSignature,
+    didActiveBurialChange,
+    didSectionChange,
+    didSelectionChange,
+    didTourChange,
+    shouldExpandMobileSheet: (
+      (
+        shouldRevealSelectedRecord
+        && resolvedMobileSheetState === MOBILE_SHEET_STATES.COLLAPSED
+      ) ||
+      (
+        shouldRevealBrowseContext
+        && resolvedMobileSheetState !== MOBILE_SHEET_STATES.FULL
+      )
+    ),
+    shouldRevealBrowseContext,
+    shouldRevealSelectedRecord,
+    shouldScrollMobileSheetToTop: Boolean(isMobile)
+      && (didSelectionChange || shouldRevealBrowseContext),
+  };
+};
+
 const canUseBrowseSearchWorker = () => (
   typeof window !== "undefined" &&
   typeof window.Worker === "function"

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildMobileSheetRevealIntent,
+} from "../src/features/browse/sidebarState";
+import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
+
+describe("sidebar state helpers", () => {
+  test("does not reveal or scroll the mobile sheet on desktop", () => {
+    expect(buildMobileSheetRevealIntent({
+      activeBurialId: "grave-2",
+      isMobile: false,
+      previousActiveBurialId: "grave-1",
+      previousSelectionSignature: "grave-1",
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+      selectedBurials: [{ id: "grave-1" }, { id: "grave-2" }],
+    })).toEqual({
+      currentSelectionSignature: "grave-1|grave-2",
+      didActiveBurialChange: true,
+      didSectionChange: false,
+      didSelectionChange: true,
+      didTourChange: false,
+      shouldExpandMobileSheet: false,
+      shouldRevealBrowseContext: false,
+      shouldRevealSelectedRecord: false,
+      shouldScrollMobileSheetToTop: false,
+    });
+  });
+
+  test("reveals a selected record from the collapsed mobile sheet", () => {
+    expect(buildMobileSheetRevealIntent({
+      activeBurialId: "grave-2",
+      isMobile: true,
+      previousActiveBurialId: "grave-1",
+      previousSelectionSignature: "grave-1",
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+      selectedBurials: [{ id: "grave-1" }, { id: "grave-2" }],
+    })).toMatchObject({
+      currentSelectionSignature: "grave-1|grave-2",
+      didActiveBurialChange: true,
+      didSelectionChange: true,
+      shouldExpandMobileSheet: true,
+      shouldRevealSelectedRecord: true,
+      shouldScrollMobileSheetToTop: true,
+    });
+  });
+
+  test("scrolls a mobile selection change without re-expanding an already open sheet", () => {
+    expect(buildMobileSheetRevealIntent({
+      activeBurialId: "grave-2",
+      isMobile: true,
+      previousActiveBurialId: "grave-1",
+      previousSelectionSignature: "grave-1",
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.FULL,
+      selectedBurials: [{ id: "grave-1" }, { id: "grave-2" }],
+    })).toMatchObject({
+      shouldExpandMobileSheet: false,
+      shouldRevealSelectedRecord: true,
+      shouldScrollMobileSheetToTop: true,
+    });
+  });
+
+  test("reveals a new browse context when no records are selected", () => {
+    expect(buildMobileSheetRevealIntent({
+      isMobile: true,
+      previousSectionFilter: "",
+      previousSelectedTour: "",
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.PEEK,
+      sectionFilter: "12",
+      selectedBurials: [],
+      selectedTour: "",
+    })).toMatchObject({
+      currentSelectionSignature: "",
+      didSectionChange: true,
+      shouldExpandMobileSheet: true,
+      shouldRevealBrowseContext: true,
+      shouldScrollMobileSheetToTop: true,
+    });
+  });
+
+  test("keeps the full mobile sheet in place for new browse context", () => {
+    expect(buildMobileSheetRevealIntent({
+      isMobile: true,
+      previousSelectedTour: "",
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.FULL,
+      selectedBurials: [],
+      selectedTour: "Notables Tour 2020",
+    })).toMatchObject({
+      didTourChange: true,
+      shouldExpandMobileSheet: false,
+      shouldRevealBrowseContext: true,
+      shouldScrollMobileSheetToTop: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extract mobile sheet reveal/scroll decisions from BurialSidebar into a pure sidebar state helper
- add focused coverage for desktop, selected-record, and browse-context reveal behavior

## Validation
- bun run check