### PR TITLE
fix: extract browse source change intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -50,6 +50,7 @@ import { buildPopupViewModel, cleanRecordValue } from "./features/map/mapRecordP
 import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
 import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
+  buildBrowseSourceChangeIntent,
   buildMobileSheetRevealIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
@@ -2046,63 +2047,47 @@ function BurialSidebar({
   }, [maximizeMobileSheet, onTourChange, setBrowseSource]);
 
   const handleBrowseSourceChange = useCallback((nextSource) => {
-    onRequestBurialDataLoad?.();
+    const intent = buildBrowseSourceChangeIntent({
+      browseSource,
+      hasSectionFilters,
+      hasTourBrowse,
+      hasTourSelection,
+      nextSource,
+    });
 
-    if (!nextSource || nextSource === "all") {
-      setBrowseSource("all");
-      if (sectionFilter || lotTierFilter) {
-        onClearSectionFilters();
-      }
-      if (selectedTour) {
-        onTourChange(null);
-      }
-      expandMobileSheet();
-      return;
+    if (intent.shouldRequestBurialDataLoad) {
+      onRequestBurialDataLoad?.();
     }
 
-    if (nextSource === "tour" && !hasTourBrowse) {
-      expandMobileSheet();
-      return;
+    if (intent.browseSourceToSet) {
+      setBrowseSource(intent.browseSourceToSet);
     }
 
-    if (
-      nextSource === browseSource &&
-      ((nextSource === "section" && !hasSectionFilters) ||
-      (nextSource === "tour" && !hasTourSelection))
-    ) {
-      setBrowseSource("all");
-      expandMobileSheet();
-      return;
-    }
-
-    setBrowseSource(nextSource);
-
-    if (nextSource === "section") {
-      if (selectedTour) {
-        onTourChange(null);
-      }
-      maximizeMobileSheet();
-      return;
-    }
-
-    if (sectionFilter || lotTierFilter) {
+    if (intent.shouldClearSectionFilters) {
       onClearSectionFilters();
     }
 
-    maximizeMobileSheet();
+    if (intent.shouldClearTourSelection) {
+      onTourChange(null);
+    }
+
+    if (intent.shouldExpandMobileSheet) {
+      expandMobileSheet();
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [
     browseSource,
     expandMobileSheet,
     hasSectionFilters,
     hasTourSelection,
     hasTourBrowse,
-    maximizeMobileSheet,
-    lotTierFilter,
     onClearSectionFilters,
     onRequestBurialDataLoad,
     onTourChange,
-    sectionFilter,
-    selectedTour,
+    maximizeMobileSheet,
     setBrowseSource,
   ]);
 

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,63 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildBrowseSourceChangeIntent = ({
+  browseSource = "all",
+  hasSectionFilters = false,
+  hasTourBrowse = true,
+  hasTourSelection = false,
+  nextSource = "",
+} = {}) => {
+  const normalizedNextSource = nextSource || "all";
+  const defaultIntent = {
+    browseSourceToSet: "",
+    shouldClearSectionFilters: false,
+    shouldClearTourSelection: false,
+    shouldExpandMobileSheet: false,
+    shouldMaximizeMobileSheet: false,
+    shouldRequestBurialDataLoad: true,
+  };
+
+  if (normalizedNextSource === "all") {
+    return {
+      ...defaultIntent,
+      browseSourceToSet: "all",
+      shouldClearSectionFilters: Boolean(hasSectionFilters),
+      shouldClearTourSelection: Boolean(hasTourSelection),
+      shouldExpandMobileSheet: true,
+    };
+  }
+
+  if (normalizedNextSource === "tour" && !hasTourBrowse) {
+    return {
+      ...defaultIntent,
+      shouldExpandMobileSheet: true,
+    };
+  }
+
+  if (
+    normalizedNextSource === browseSource &&
+    (
+      (normalizedNextSource === "section" && !hasSectionFilters) ||
+      (normalizedNextSource === "tour" && !hasTourSelection)
+    )
+  ) {
+    return {
+      ...defaultIntent,
+      browseSourceToSet: "all",
+      shouldExpandMobileSheet: true,
+    };
+  }
+
+  return {
+    ...defaultIntent,
+    browseSourceToSet: normalizedNextSource,
+    shouldClearSectionFilters: normalizedNextSource !== "section" && Boolean(hasSectionFilters),
+    shouldClearTourSelection: normalizedNextSource === "section" && Boolean(hasTourSelection),
+    shouldMaximizeMobileSheet: true,
+  };
+};
+
 export const buildMobileSheetRevealIntent = ({
   activeBurialId = "",
   isMobile = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildBrowseSourceChangeIntent,
   buildMobileSheetRevealIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
@@ -90,6 +91,88 @@ describe("sidebar state helpers", () => {
       shouldExpandMobileSheet: false,
       shouldRevealBrowseContext: true,
       shouldScrollMobileSheetToTop: true,
+    });
+  });
+
+  test("builds browse-source intent for returning to all results", () => {
+    expect(buildBrowseSourceChangeIntent({
+      hasSectionFilters: true,
+      hasTourSelection: true,
+      nextSource: "all",
+    })).toEqual({
+      browseSourceToSet: "all",
+      shouldClearSectionFilters: true,
+      shouldClearTourSelection: true,
+      shouldExpandMobileSheet: true,
+      shouldMaximizeMobileSheet: false,
+      shouldRequestBurialDataLoad: true,
+    });
+  });
+
+  test("builds browse-source intent for unavailable tour browse", () => {
+    expect(buildBrowseSourceChangeIntent({
+      hasTourBrowse: false,
+      nextSource: "tour",
+    })).toEqual({
+      browseSourceToSet: "",
+      shouldClearSectionFilters: false,
+      shouldClearTourSelection: false,
+      shouldExpandMobileSheet: true,
+      shouldMaximizeMobileSheet: false,
+      shouldRequestBurialDataLoad: true,
+    });
+  });
+
+  test("toggles an empty active scoped browse source back to all", () => {
+    expect(buildBrowseSourceChangeIntent({
+      browseSource: "section",
+      hasSectionFilters: false,
+      nextSource: "section",
+    })).toEqual({
+      browseSourceToSet: "all",
+      shouldClearSectionFilters: false,
+      shouldClearTourSelection: false,
+      shouldExpandMobileSheet: true,
+      shouldMaximizeMobileSheet: false,
+      shouldRequestBurialDataLoad: true,
+    });
+
+    expect(buildBrowseSourceChangeIntent({
+      browseSource: "tour",
+      hasTourBrowse: true,
+      hasTourSelection: false,
+      nextSource: "tour",
+    })).toMatchObject({
+      browseSourceToSet: "all",
+      shouldExpandMobileSheet: true,
+      shouldMaximizeMobileSheet: false,
+    });
+  });
+
+  test("builds browse-source intent for entering section and tour scopes", () => {
+    expect(buildBrowseSourceChangeIntent({
+      hasTourSelection: true,
+      nextSource: "section",
+    })).toEqual({
+      browseSourceToSet: "section",
+      shouldClearSectionFilters: false,
+      shouldClearTourSelection: true,
+      shouldExpandMobileSheet: false,
+      shouldMaximizeMobileSheet: true,
+      shouldRequestBurialDataLoad: true,
+    });
+
+    expect(buildBrowseSourceChangeIntent({
+      hasSectionFilters: true,
+      hasTourBrowse: true,
+      nextSource: "tour",
+    })).toEqual({
+      browseSourceToSet: "tour",
+      shouldClearSectionFilters: true,
+      shouldClearTourSelection: false,
+      shouldExpandMobileSheet: false,
+      shouldMaximizeMobileSheet: true,
+      shouldRequestBurialDataLoad: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- extract browse source switching decisions from BurialSidebar into a pure sidebar state helper
- cover all-results, unavailable tour browse, empty scoped toggle, and section/tour scope transitions

## Validation
- bun run check