### PR TITLE
fix: extract clear all browse state intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -51,6 +51,7 @@ import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
 import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
   buildBrowseSourceChangeIntent,
+  buildClearAllBrowseStateIntent,
   buildMobileSheetRevealIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
@@ -2128,22 +2129,33 @@ function BurialSidebar({
   ]);
 
   const handleClearAllBrowseState = useCallback(() => {
-    setBrowseQuery("");
-    setBrowseSource("all");
-    setIsSelectedSummaryExpanded(false);
+    const intent = buildClearAllBrowseStateIntent({
+      lotTierFilter,
+      sectionFilter,
+      selectedTour,
+    });
 
-    if (sectionFilter) {
+    setBrowseQuery(intent.browseQueryToSet);
+    setBrowseSource(intent.browseSourceToSet);
+    setIsSelectedSummaryExpanded(intent.isSelectedSummaryExpandedToSet);
+
+    if (intent.shouldClearSectionFilters) {
       onClearSectionFilters();
-    } else if (lotTierFilter) {
-      onLotTierFilterChange("");
+    } else if (intent.shouldClearLotTierFilter) {
+      onLotTierFilterChange(intent.lotTierFilterToSet);
     }
 
-    if (selectedTour) {
-      onTourChange(null);
+    if (intent.shouldClearTourSelection) {
+      onTourChange(intent.selectedTourToSet);
     }
 
-    onClearSelectedBurials();
-    expandMobileSheet();
+    if (intent.shouldClearSelectedBurials) {
+      onClearSelectedBurials();
+    }
+
+    if (intent.shouldExpandMobileSheet) {
+      expandMobileSheet();
+    }
   }, [
     expandMobileSheet,
     lotTierFilter,

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,29 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildClearAllBrowseStateIntent = ({
+  lotTierFilter = "",
+  sectionFilter = "",
+  selectedTour = "",
+} = {}) => {
+  const hasSectionFilter = Boolean(sectionFilter);
+  const hasLotTierFilter = Boolean(lotTierFilter);
+  const hasSelectedTour = Boolean(selectedTour);
+
+  return {
+    browseQueryToSet: "",
+    browseSourceToSet: "all",
+    isSelectedSummaryExpandedToSet: false,
+    lotTierFilterToSet: "",
+    selectedTourToSet: null,
+    shouldClearSectionFilters: hasSectionFilter,
+    shouldClearSelectedBurials: true,
+    shouldClearTourSelection: hasSelectedTour,
+    shouldClearLotTierFilter: !hasSectionFilter && hasLotTierFilter,
+    shouldExpandMobileSheet: true,
+  };
+};
+
 export const buildBrowseSourceChangeIntent = ({
   browseSource = "all",
   hasSectionFilters = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   buildBrowseSourceChangeIntent,
+  buildClearAllBrowseStateIntent,
   buildMobileSheetRevealIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
@@ -173,6 +174,54 @@ describe("sidebar state helpers", () => {
       shouldExpandMobileSheet: false,
       shouldMaximizeMobileSheet: true,
       shouldRequestBurialDataLoad: true,
+    });
+  });
+
+  test("builds clear-all intent with section reset taking precedence over lot-tier reset", () => {
+    expect(buildClearAllBrowseStateIntent({
+      lotTierFilter: "A",
+      sectionFilter: "12",
+      selectedTour: "Notables Tour 2020",
+    })).toEqual({
+      browseQueryToSet: "",
+      browseSourceToSet: "all",
+      isSelectedSummaryExpandedToSet: false,
+      lotTierFilterToSet: "",
+      selectedTourToSet: null,
+      shouldClearSectionFilters: true,
+      shouldClearSelectedBurials: true,
+      shouldClearTourSelection: true,
+      shouldClearLotTierFilter: false,
+      shouldExpandMobileSheet: true,
+    });
+  });
+
+  test("builds clear-all intent that clears lot-tier directly when no section is active", () => {
+    expect(buildClearAllBrowseStateIntent({
+      lotTierFilter: "B",
+      sectionFilter: "",
+      selectedTour: "",
+    })).toMatchObject({
+      lotTierFilterToSet: "",
+      selectedTourToSet: null,
+      shouldClearSectionFilters: false,
+      shouldClearLotTierFilter: true,
+      shouldClearTourSelection: false,
+    });
+  });
+
+  test("builds clear-all intent for an already idle browse state", () => {
+    expect(buildClearAllBrowseStateIntent()).toEqual({
+      browseQueryToSet: "",
+      browseSourceToSet: "all",
+      isSelectedSummaryExpandedToSet: false,
+      lotTierFilterToSet: "",
+      selectedTourToSet: null,
+      shouldClearSectionFilters: false,
+      shouldClearSelectedBurials: true,
+      shouldClearTourSelection: false,
+      shouldClearLotTierFilter: false,
+      shouldExpandMobileSheet: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- move clear-all browse reset decisions into a tested sidebar state helper
- preserve section reset precedence over lot/tier reset while keeping selected tour and selected burials cleanup explicit

## Validation
- bun run check