### PR TITLE
fix: extract mobile search panel toggle intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -52,6 +52,7 @@ import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
@@ -2099,26 +2100,30 @@ function BurialSidebar({
   }, [browseSource, hasTourBrowse, setBrowseSource]);
 
   const handleToggleMobileSearchPanel = useCallback(() => {
-    if (!isMobile) {
-      return;
+    const intent = buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: Boolean(onRequestHideChrome),
+      isMobile,
+      isMobileSearchPanelCollapsedByControl,
+      resolvedMobileSheetState,
+    });
+
+    if (intent.shouldSetMobileSearchPanelCollapsedByControl) {
+      setIsMobileSearchPanelCollapsedByControl(
+        intent.isMobileSearchPanelCollapsedByControlToSet
+      );
     }
 
-    const isCurrentlyCollapsed = isMobileSearchPanelCollapsedByControl
-      || resolvedMobileSheetState === MOBILE_SHEET_STATES.COLLAPSED;
-
-    if (isCurrentlyCollapsed) {
-      setIsMobileSearchPanelCollapsedByControl(false);
+    if (intent.shouldExpandMobileSheet) {
       expandMobileSheet();
-      return;
     }
 
-    if (onRequestHideChrome) {
+    if (intent.shouldRequestHideChrome) {
       onRequestHideChrome();
-      return;
     }
 
-    setIsMobileSearchPanelCollapsedByControl(true);
-    collapseMobileSheet();
+    if (intent.shouldCollapseMobileSheet) {
+      collapseMobileSheet();
+    }
   }, [
     collapseMobileSheet,
     expandMobileSheet,

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,51 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildMobileSearchPanelToggleIntent = ({
+  canRequestHideChrome = false,
+  isMobile = false,
+  isMobileSearchPanelCollapsedByControl = false,
+  resolvedMobileSheetState = MOBILE_SHEET_STATES.PEEK,
+} = {}) => {
+  const defaultIntent = {
+    isMobileSearchPanelCollapsedByControlToSet: null,
+    shouldCollapseMobileSheet: false,
+    shouldExpandMobileSheet: false,
+    shouldRequestHideChrome: false,
+    shouldSetMobileSearchPanelCollapsedByControl: false,
+  };
+
+  if (!isMobile) {
+    return defaultIntent;
+  }
+
+  const isCurrentlyCollapsed = Boolean(isMobileSearchPanelCollapsedByControl)
+    || resolvedMobileSheetState === MOBILE_SHEET_STATES.COLLAPSED;
+
+  if (isCurrentlyCollapsed) {
+    return {
+      ...defaultIntent,
+      isMobileSearchPanelCollapsedByControlToSet: false,
+      shouldExpandMobileSheet: true,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
+    };
+  }
+
+  if (canRequestHideChrome) {
+    return {
+      ...defaultIntent,
+      shouldRequestHideChrome: true,
+    };
+  }
+
+  return {
+    ...defaultIntent,
+    isMobileSearchPanelCollapsedByControlToSet: true,
+    shouldCollapseMobileSheet: true,
+    shouldSetMobileSearchPanelCollapsedByControl: true,
+  };
+};
+
 export const buildClearAllBrowseStateIntent = ({
   lotTierFilter = "",
   sectionFilter = "",

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
@@ -222,6 +223,77 @@ describe("sidebar state helpers", () => {
       shouldClearTourSelection: false,
       shouldClearLotTierFilter: false,
       shouldExpandMobileSheet: true,
+    });
+  });
+
+  test("builds mobile search-panel toggle intent as a desktop no-op", () => {
+    expect(buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: true,
+      isMobile: false,
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.PEEK,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: null,
+      shouldCollapseMobileSheet: false,
+      shouldExpandMobileSheet: false,
+      shouldRequestHideChrome: false,
+      shouldSetMobileSearchPanelCollapsedByControl: false,
+    });
+  });
+
+  test("builds mobile search-panel toggle intent to reopen a collapsed panel", () => {
+    expect(buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: true,
+      isMobile: true,
+      isMobileSearchPanelCollapsedByControl: true,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.PEEK,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: false,
+      shouldCollapseMobileSheet: false,
+      shouldExpandMobileSheet: true,
+      shouldRequestHideChrome: false,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+
+    expect(buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: false,
+      isMobile: true,
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+    })).toMatchObject({
+      isMobileSearchPanelCollapsedByControlToSet: false,
+      shouldExpandMobileSheet: true,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+  });
+
+  test("builds mobile search-panel toggle intent to request external chrome hiding first", () => {
+    expect(buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: true,
+      isMobile: true,
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.PEEK,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: null,
+      shouldCollapseMobileSheet: false,
+      shouldExpandMobileSheet: false,
+      shouldRequestHideChrome: true,
+      shouldSetMobileSearchPanelCollapsedByControl: false,
+    });
+  });
+
+  test("builds mobile search-panel toggle intent to locally collapse when chrome cannot hide", () => {
+    expect(buildMobileSearchPanelToggleIntent({
+      canRequestHideChrome: false,
+      isMobile: true,
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.FULL,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: true,
+      shouldCollapseMobileSheet: true,
+      shouldExpandMobileSheet: false,
+      shouldRequestHideChrome: false,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- move mobile search-panel toggle decisions into a tested sidebar state helper
- cover desktop no-op, reopening collapsed panels, native chrome hide requests, and local collapse fallback

## Validation
- bun run check