### PR TITLE
fix: extract browse result select intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -50,6 +50,7 @@ import { buildPopupViewModel, cleanRecordValue } from "./features/map/mapRecordP
 import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
 import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
+  buildBrowseResultSelectIntent,
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
   buildMobileSearchPanelToggleIntent,
@@ -1992,11 +1993,15 @@ function BurialSidebar({
   }, [setBrowseQuery]);
 
   const handleBrowseResultSelect = useCallback((result) => {
+    const intent = buildBrowseResultSelectIntent({
+      isMobile,
+      selectedBurialsLength: selectedBurials.length,
+    });
+
     onBrowseResultSelect(result);
-    if (isMobile) {
-      if (selectedBurials.length === 0) {
-        setIsSelectedSummaryExpanded(true);
-      }
+
+    if (intent.shouldSetSelectedSummaryExpanded) {
+      setIsSelectedSummaryExpanded(intent.isSelectedSummaryExpandedToSet);
     }
   }, [
     isMobile,

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,19 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildBrowseResultSelectIntent = ({
+  isMobile = false,
+  selectedBurialsLength = 0,
+} = {}) => {
+  const shouldSetSelectedSummaryExpanded = Boolean(isMobile)
+    && Number(selectedBurialsLength) === 0;
+
+  return {
+    isSelectedSummaryExpandedToSet: shouldSetSelectedSummaryExpanded ? true : null,
+    shouldSetSelectedSummaryExpanded,
+  };
+};
+
 export const buildMobileSearchPanelToggleIntent = ({
   canRequestHideChrome = false,
   isMobile = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildBrowseResultSelectIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
 } from "../src/features/browse/sidebarState";
@@ -294,6 +295,34 @@ describe("sidebar state helpers", () => {
       shouldExpandMobileSheet: false,
       shouldRequestHideChrome: false,
       shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+  });
+
+  test("builds browse-result select intent to reveal an empty mobile selection summary", () => {
+    expect(buildBrowseResultSelectIntent({
+      isMobile: true,
+      selectedBurialsLength: 0,
+    })).toEqual({
+      isSelectedSummaryExpandedToSet: true,
+      shouldSetSelectedSummaryExpanded: true,
+    });
+  });
+
+  test("does not expand selected summary for desktop or existing mobile selections", () => {
+    expect(buildBrowseResultSelectIntent({
+      isMobile: false,
+      selectedBurialsLength: 0,
+    })).toEqual({
+      isSelectedSummaryExpandedToSet: null,
+      shouldSetSelectedSummaryExpanded: false,
+    });
+
+    expect(buildBrowseResultSelectIntent({
+      isMobile: true,
+      selectedBurialsLength: 2,
+    })).toEqual({
+      isSelectedSummaryExpandedToSet: null,
+      shouldSetSelectedSummaryExpanded: false,
     });
   });
 });


### PR DESCRIPTION
## Summary
- move browse-result selection summary expansion into a tested sidebar state helper
- cover mobile empty-selection behavior plus desktop/existing-selection no-op cases

## Validation
- bun run check