### PR TITLE
fix: extract tour selection intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -55,6 +55,7 @@ import {
   buildClearAllBrowseStateIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
+  buildTourSelectionIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
 } from "./features/browse/sidebarState";
@@ -2040,11 +2041,22 @@ function BurialSidebar({
   }, [maximizeMobileSheet, onClearSectionFilters, setBrowseSource]);
 
   const handleTourSelection = useCallback((tourName) => {
-    if (!hasTourBrowse) return;
+    const intent = buildTourSelectionIntent({
+      hasTourBrowse,
+      tourName,
+    });
 
-    setBrowseSource("tour");
-    onTourChange(tourName);
-    maximizeMobileSheet();
+    if (intent.shouldSetBrowseSource) {
+      setBrowseSource(intent.browseSourceToSet);
+    }
+
+    if (intent.shouldSetTourSelection) {
+      onTourChange(intent.selectedTourToSet);
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [hasTourBrowse, maximizeMobileSheet, onTourChange, setBrowseSource]);
 
   const handleClearTourSelection = useCallback(() => {

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -35,6 +35,21 @@ export const buildBrowseResultSelectIntent = ({
   };
 };
 
+export const buildTourSelectionIntent = ({
+  hasTourBrowse = false,
+  tourName = "",
+} = {}) => {
+  const shouldSelectTour = Boolean(hasTourBrowse);
+
+  return {
+    browseSourceToSet: shouldSelectTour ? "tour" : "",
+    selectedTourToSet: shouldSelectTour ? tourName : null,
+    shouldMaximizeMobileSheet: shouldSelectTour,
+    shouldSetBrowseSource: shouldSelectTour,
+    shouldSetTourSelection: shouldSelectTour,
+  };
+};
+
 export const buildMobileSearchPanelToggleIntent = ({
   canRequestHideChrome = false,
   isMobile = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -6,6 +6,7 @@ import {
   buildBrowseResultSelectIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
+  buildTourSelectionIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
 
@@ -323,6 +324,30 @@ describe("sidebar state helpers", () => {
     })).toEqual({
       isSelectedSummaryExpandedToSet: null,
       shouldSetSelectedSummaryExpanded: false,
+    });
+  });
+
+  test("builds tour-selection intent only when tour browse is available", () => {
+    expect(buildTourSelectionIntent({
+      hasTourBrowse: false,
+      tourName: "Notables Tour 2020",
+    })).toEqual({
+      browseSourceToSet: "",
+      selectedTourToSet: null,
+      shouldMaximizeMobileSheet: false,
+      shouldSetBrowseSource: false,
+      shouldSetTourSelection: false,
+    });
+
+    expect(buildTourSelectionIntent({
+      hasTourBrowse: true,
+      tourName: "Notables Tour 2020",
+    })).toEqual({
+      browseSourceToSet: "tour",
+      selectedTourToSet: "Notables Tour 2020",
+      shouldMaximizeMobileSheet: true,
+      shouldSetBrowseSource: true,
+      shouldSetTourSelection: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- move tour selection guard and side-effect decisions into a tested sidebar state helper
- cover available and unavailable tour browse behavior

## Validation
- bun run check