### PR TITLE
fix: extract mobile search panel reset intent

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -53,6 +53,7 @@ import {
   buildBrowseResultSelectIntent,
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
   buildTourSelectionIntent,
@@ -1923,13 +1924,15 @@ function BurialSidebar({
   }, [handleSheetSpringEnd, onMobileSheetViewportChange]);
 
   useEffect(() => {
-    if (!isMobile) {
-      setIsMobileSearchPanelCollapsedByControl(false);
-      return;
-    }
+    const intent = buildMobileSearchPanelCollapseResetIntent({
+      isMobile,
+      resolvedMobileSheetState,
+    });
 
-    if (resolvedMobileSheetState !== MOBILE_SHEET_STATES.COLLAPSED) {
-      setIsMobileSearchPanelCollapsedByControl(false);
+    if (intent.shouldSetMobileSearchPanelCollapsedByControl) {
+      setIsMobileSearchPanelCollapsedByControl(
+        intent.isMobileSearchPanelCollapsedByControlToSet
+      );
     }
   }, [isMobile, resolvedMobileSheetState]);
 

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -50,6 +50,19 @@ export const buildTourSelectionIntent = ({
   };
 };
 
+export const buildMobileSearchPanelCollapseResetIntent = ({
+  isMobile = false,
+  resolvedMobileSheetState = MOBILE_SHEET_STATES.PEEK,
+} = {}) => {
+  const shouldResetCollapsedControl = !isMobile
+    || resolvedMobileSheetState !== MOBILE_SHEET_STATES.COLLAPSED;
+
+  return {
+    isMobileSearchPanelCollapsedByControlToSet: shouldResetCollapsedControl ? false : null,
+    shouldSetMobileSearchPanelCollapsedByControl: shouldResetCollapsedControl,
+  };
+};
+
 export const buildMobileSearchPanelToggleIntent = ({
   canRequestHideChrome = false,
   isMobile = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -4,6 +4,7 @@ import {
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
   buildBrowseResultSelectIntent,
+  buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
   buildTourSelectionIntent,
@@ -296,6 +297,32 @@ describe("sidebar state helpers", () => {
       shouldExpandMobileSheet: false,
       shouldRequestHideChrome: false,
       shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+  });
+
+  test("builds mobile search-panel collapse reset intent outside the collapsed mobile state", () => {
+    expect(buildMobileSearchPanelCollapseResetIntent({
+      isMobile: false,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: false,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+
+    expect(buildMobileSearchPanelCollapseResetIntent({
+      isMobile: true,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.PEEK,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: false,
+      shouldSetMobileSearchPanelCollapsedByControl: true,
+    });
+
+    expect(buildMobileSearchPanelCollapseResetIntent({
+      isMobile: true,
+      resolvedMobileSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+    })).toEqual({
+      isMobileSearchPanelCollapsedByControlToSet: null,
+      shouldSetMobileSearchPanelCollapsedByControl: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- move mobile search panel collapse reset decisions into a tested sidebar state helper
- cover desktop, expanded mobile, and collapsed mobile states

## Validation
- bun run check