### PR TITLE
fix: extract remaining browse sidebar intents

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -57,6 +57,7 @@ import {
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
+  buildSectionSelectionIntent,
   buildTourSelectionIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
@@ -2016,10 +2017,23 @@ function BurialSidebar({
   ]);
 
   const handleSectionSelection = useCallback((nextSection) => {
-    onRequestBurialDataLoad?.();
-    setBrowseSource("section");
-    onSectionChange(nextSection || "");
-    maximizeMobileSheet();
+    const intent = buildSectionSelectionIntent({ nextSection });
+
+    if (intent.shouldRequestBurialDataLoad) {
+      onRequestBurialDataLoad?.();
+    }
+
+    if (intent.shouldSetBrowseSource) {
+      setBrowseSource(intent.browseSourceToSet);
+    }
+
+    if (intent.shouldSetSectionFilter) {
+      onSectionChange(intent.sectionFilterToSet);
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onRequestBurialDataLoad, onSectionChange, setBrowseSource]);
 
   const handleToggleSectionMarkers = useCallback(() => {

--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -50,15 +50,22 @@ import { buildPopupViewModel, cleanRecordValue } from "./features/map/mapRecordP
 import { resolvePortraitImageName } from "./features/tours/tourDerivedData";
 import { MOBILE_SHEET_STATES } from "./features/browse/mobileSheetGeometry";
 import {
+  buildBrowseQueryChangeIntent,
   buildBrowseResultSelectIntent,
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildClearBrowseQueryIntent,
+  buildClearSectionFiltersIntent,
   buildClearTourSelectionIntent,
+  buildFilterTypeSelectionIntent,
+  buildLotTierChangeIntent,
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
   buildSectionSelectionIntent,
+  buildToggleSectionMarkersIntent,
   buildTourSelectionIntent,
+  buildUnavailableTourBrowseResetIntent,
   useBurialSidebarBrowseState,
   useBurialSidebarMobileSheetState,
 } from "./features/browse/sidebarState";
@@ -1990,12 +1997,25 @@ function BurialSidebar({
   ]);
 
   const handleBrowseQueryChange = useCallback((event) => {
-    onRequestBurialDataLoad?.();
-    setBrowseQuery(event.target.value);
+    const intent = buildBrowseQueryChangeIntent({
+      nextQuery: event.target.value,
+    });
+
+    if (intent.shouldRequestBurialDataLoad) {
+      onRequestBurialDataLoad?.();
+    }
+
+    if (intent.shouldSetBrowseQuery) {
+      setBrowseQuery(intent.browseQueryToSet);
+    }
   }, [onRequestBurialDataLoad, setBrowseQuery]);
 
   const handleClearBrowseQuery = useCallback(() => {
-    setBrowseQuery("");
+    const intent = buildClearBrowseQueryIntent();
+
+    if (intent.shouldSetBrowseQuery) {
+      setBrowseQuery(intent.browseQueryToSet);
+    }
   }, [setBrowseQuery]);
 
   const handleBrowseResultSelect = useCallback((result) => {
@@ -2037,25 +2057,59 @@ function BurialSidebar({
   }, [maximizeMobileSheet, onRequestBurialDataLoad, onSectionChange, setBrowseSource]);
 
   const handleToggleSectionMarkers = useCallback(() => {
-    onRequestBurialDataLoad?.();
-    onToggleSectionMarkers();
-    maximizeMobileSheet();
+    const intent = buildToggleSectionMarkersIntent();
+
+    if (intent.shouldRequestBurialDataLoad) {
+      onRequestBurialDataLoad?.();
+    }
+
+    if (intent.shouldToggleSectionMarkers) {
+      onToggleSectionMarkers();
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onRequestBurialDataLoad, onToggleSectionMarkers]);
 
   const handleFilterTypeSelection = useCallback((nextFilterType) => {
-    onFilterTypeChange(nextFilterType);
-    maximizeMobileSheet();
+    const intent = buildFilterTypeSelectionIntent({ nextFilterType });
+
+    if (intent.shouldSetFilterType) {
+      onFilterTypeChange(intent.filterTypeToSet);
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onFilterTypeChange]);
 
   const handleLotTierChange = useCallback((nextValue) => {
-    onLotTierFilterChange(nextValue);
-    maximizeMobileSheet();
+    const intent = buildLotTierChangeIntent({ nextValue });
+
+    if (intent.shouldSetLotTierFilter) {
+      onLotTierFilterChange(intent.lotTierFilterToSet);
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onLotTierFilterChange]);
 
   const handleClearSectionFilters = useCallback(() => {
-    setBrowseSource("section");
-    onClearSectionFilters();
-    maximizeMobileSheet();
+    const intent = buildClearSectionFiltersIntent();
+
+    if (intent.shouldSetBrowseSource) {
+      setBrowseSource(intent.browseSourceToSet);
+    }
+
+    if (intent.shouldClearSectionFilters) {
+      onClearSectionFilters();
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onClearSectionFilters, setBrowseSource]);
 
   const handleTourSelection = useCallback((tourName) => {
@@ -2139,8 +2193,13 @@ function BurialSidebar({
   ]);
 
   useEffect(() => {
-    if (!hasTourBrowse && browseSource === "tour") {
-      setBrowseSource("all");
+    const intent = buildUnavailableTourBrowseResetIntent({
+      browseSource,
+      hasTourBrowse,
+    });
+
+    if (intent.shouldSetBrowseSource) {
+      setBrowseSource(intent.browseSourceToSet);
     }
   }, [browseSource, hasTourBrowse, setBrowseSource]);
 

--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -53,6 +53,7 @@ import {
   buildBrowseResultSelectIntent,
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildClearTourSelectionIntent,
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
@@ -2063,9 +2064,19 @@ function BurialSidebar({
   }, [hasTourBrowse, maximizeMobileSheet, onTourChange, setBrowseSource]);
 
   const handleClearTourSelection = useCallback(() => {
-    setBrowseSource("tour");
-    onTourChange(null);
-    maximizeMobileSheet();
+    const intent = buildClearTourSelectionIntent();
+
+    if (intent.shouldSetBrowseSource) {
+      setBrowseSource(intent.browseSourceToSet);
+    }
+
+    if (intent.shouldSetTourSelection) {
+      onTourChange(intent.selectedTourToSet);
+    }
+
+    if (intent.shouldMaximizeMobileSheet) {
+      maximizeMobileSheet();
+    }
   }, [maximizeMobileSheet, onTourChange, setBrowseSource]);
 
   const handleBrowseSourceChange = useCallback((nextSource) => {

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -50,6 +50,14 @@ export const buildTourSelectionIntent = ({
   };
 };
 
+export const buildClearTourSelectionIntent = () => ({
+  browseSourceToSet: "tour",
+  selectedTourToSet: null,
+  shouldMaximizeMobileSheet: true,
+  shouldSetBrowseSource: true,
+  shouldSetTourSelection: true,
+});
+
 export const buildMobileSearchPanelCollapseResetIntent = ({
   isMobile = false,
   resolvedMobileSheetState = MOBILE_SHEET_STATES.PEEK,

--- a/src/features/browse/sidebarState.js
+++ b/src/features/browse/sidebarState.js
@@ -22,6 +22,19 @@ const ASYNC_BROWSE_RECORD_THRESHOLD = 5000;
 const BROWSE_RESULTS_CACHE_LIMIT = 24;
 let browseSearchWorkerFactoryPromise = null;
 
+export const buildBrowseQueryChangeIntent = ({
+  nextQuery = "",
+} = {}) => ({
+  browseQueryToSet: nextQuery,
+  shouldRequestBurialDataLoad: true,
+  shouldSetBrowseQuery: true,
+});
+
+export const buildClearBrowseQueryIntent = () => ({
+  browseQueryToSet: "",
+  shouldSetBrowseQuery: true,
+});
+
 export const buildBrowseResultSelectIntent = ({
   isMobile = false,
   selectedBurialsLength = 0,
@@ -57,6 +70,58 @@ export const buildClearTourSelectionIntent = () => ({
   shouldSetBrowseSource: true,
   shouldSetTourSelection: true,
 });
+
+export const buildSectionSelectionIntent = ({
+  nextSection = "",
+} = {}) => ({
+  browseSourceToSet: "section",
+  sectionFilterToSet: nextSection || "",
+  shouldMaximizeMobileSheet: true,
+  shouldRequestBurialDataLoad: true,
+  shouldSetBrowseSource: true,
+  shouldSetSectionFilter: true,
+});
+
+export const buildToggleSectionMarkersIntent = () => ({
+  shouldMaximizeMobileSheet: true,
+  shouldRequestBurialDataLoad: true,
+  shouldToggleSectionMarkers: true,
+});
+
+export const buildFilterTypeSelectionIntent = ({
+  nextFilterType = "",
+} = {}) => ({
+  filterTypeToSet: nextFilterType,
+  shouldMaximizeMobileSheet: true,
+  shouldSetFilterType: true,
+});
+
+export const buildLotTierChangeIntent = ({
+  nextValue = "",
+} = {}) => ({
+  lotTierFilterToSet: nextValue,
+  shouldMaximizeMobileSheet: true,
+  shouldSetLotTierFilter: true,
+});
+
+export const buildClearSectionFiltersIntent = () => ({
+  browseSourceToSet: "section",
+  shouldClearSectionFilters: true,
+  shouldMaximizeMobileSheet: true,
+  shouldSetBrowseSource: true,
+});
+
+export const buildUnavailableTourBrowseResetIntent = ({
+  browseSource = "all",
+  hasTourBrowse = true,
+} = {}) => {
+  const shouldResetBrowseSource = !hasTourBrowse && browseSource === "tour";
+
+  return {
+    browseSourceToSet: shouldResetBrowseSource ? "all" : "",
+    shouldSetBrowseSource: shouldResetBrowseSource,
+  };
+};
 
 export const buildMobileSearchPanelCollapseResetIntent = ({
   isMobile = false,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -1,15 +1,22 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildBrowseQueryChangeIntent,
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildClearBrowseQueryIntent,
+  buildClearSectionFiltersIntent,
   buildClearTourSelectionIntent,
   buildBrowseResultSelectIntent,
+  buildFilterTypeSelectionIntent,
+  buildLotTierChangeIntent,
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
   buildSectionSelectionIntent,
+  buildToggleSectionMarkersIntent,
   buildTourSelectionIntent,
+  buildUnavailableTourBrowseResetIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
 
@@ -231,6 +238,19 @@ describe("sidebar state helpers", () => {
     });
   });
 
+  test("builds browse query intents", () => {
+    expect(buildBrowseQueryChangeIntent({ nextQuery: "Ada" })).toEqual({
+      browseQueryToSet: "Ada",
+      shouldRequestBurialDataLoad: true,
+      shouldSetBrowseQuery: true,
+    });
+
+    expect(buildClearBrowseQueryIntent()).toEqual({
+      browseQueryToSet: "",
+      shouldSetBrowseQuery: true,
+    });
+  });
+
   test("builds mobile search-panel toggle intent as a desktop no-op", () => {
     expect(buildMobileSearchPanelToggleIntent({
       canRequestHideChrome: true,
@@ -404,6 +424,51 @@ describe("sidebar state helpers", () => {
       browseSourceToSet: "section",
       sectionFilterToSet: "",
       shouldRequestBurialDataLoad: true,
+    });
+  });
+
+  test("builds section marker and scoped filter intents", () => {
+    expect(buildToggleSectionMarkersIntent()).toEqual({
+      shouldMaximizeMobileSheet: true,
+      shouldRequestBurialDataLoad: true,
+      shouldToggleSectionMarkers: true,
+    });
+
+    expect(buildFilterTypeSelectionIntent({ nextFilterType: "tier" })).toEqual({
+      filterTypeToSet: "tier",
+      shouldMaximizeMobileSheet: true,
+      shouldSetFilterType: true,
+    });
+
+    expect(buildLotTierChangeIntent({ nextValue: "A" })).toEqual({
+      lotTierFilterToSet: "A",
+      shouldMaximizeMobileSheet: true,
+      shouldSetLotTierFilter: true,
+    });
+  });
+
+  test("builds clear-section and unavailable-tour reset intents", () => {
+    expect(buildClearSectionFiltersIntent()).toEqual({
+      browseSourceToSet: "section",
+      shouldClearSectionFilters: true,
+      shouldMaximizeMobileSheet: true,
+      shouldSetBrowseSource: true,
+    });
+
+    expect(buildUnavailableTourBrowseResetIntent({
+      browseSource: "tour",
+      hasTourBrowse: false,
+    })).toEqual({
+      browseSourceToSet: "all",
+      shouldSetBrowseSource: true,
+    });
+
+    expect(buildUnavailableTourBrowseResetIntent({
+      browseSource: "section",
+      hasTourBrowse: false,
+    })).toEqual({
+      browseSourceToSet: "",
+      shouldSetBrowseSource: false,
     });
   });
 });

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildBrowseSourceChangeIntent,
   buildClearAllBrowseStateIntent,
+  buildClearTourSelectionIntent,
   buildBrowseResultSelectIntent,
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
@@ -372,6 +373,16 @@ describe("sidebar state helpers", () => {
     })).toEqual({
       browseSourceToSet: "tour",
       selectedTourToSet: "Notables Tour 2020",
+      shouldMaximizeMobileSheet: true,
+      shouldSetBrowseSource: true,
+      shouldSetTourSelection: true,
+    });
+  });
+
+  test("builds clear-tour-selection intent that keeps tour browse active", () => {
+    expect(buildClearTourSelectionIntent()).toEqual({
+      browseSourceToSet: "tour",
+      selectedTourToSet: null,
       shouldMaximizeMobileSheet: true,
       shouldSetBrowseSource: true,
       shouldSetTourSelection: true,

--- a/test/sidebarState.test.js
+++ b/test/sidebarState.test.js
@@ -8,6 +8,7 @@ import {
   buildMobileSearchPanelCollapseResetIntent,
   buildMobileSearchPanelToggleIntent,
   buildMobileSheetRevealIntent,
+  buildSectionSelectionIntent,
   buildTourSelectionIntent,
 } from "../src/features/browse/sidebarState";
 import { MOBILE_SHEET_STATES } from "../src/features/browse/mobileSheetGeometry";
@@ -386,6 +387,23 @@ describe("sidebar state helpers", () => {
       shouldMaximizeMobileSheet: true,
       shouldSetBrowseSource: true,
       shouldSetTourSelection: true,
+    });
+  });
+
+  test("builds section-selection intent with normalized empty section values", () => {
+    expect(buildSectionSelectionIntent({ nextSection: "12" })).toEqual({
+      browseSourceToSet: "section",
+      sectionFilterToSet: "12",
+      shouldMaximizeMobileSheet: true,
+      shouldRequestBurialDataLoad: true,
+      shouldSetBrowseSource: true,
+      shouldSetSectionFilter: true,
+    });
+
+    expect(buildSectionSelectionIntent({ nextSection: null })).toMatchObject({
+      browseSourceToSet: "section",
+      sectionFilterToSet: "",
+      shouldRequestBurialDataLoad: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- move remaining simple browse sidebar callback decisions into tested sidebar state intent helpers
- cover browse query, section selection, section marker toggle, scoped filters, clear section filters, and unavailable tour reset behavior

## Validation
- bun test test/sidebarState.test.js
- bun run check