### PR TITLE
fix: extract sidebar presentation helpers

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -22,10 +22,12 @@ import "react-spring-bottom-sheet/dist/style.css";
 import { APP_PROFILE } from "./features/fab/profile";
 import BrowseWorkspacePanel, { BrowseSearchField } from "./features/browse/BrowseWorkspacePanel";
 import {
+  buildAutocompletePresentation,
   buildBrowseResultsPanelPresentation,
   buildLifeDatesSummary,
   buildBrowseEmptyActionSpecs,
   buildBrowseScopeChips,
+  buildMobileSearchPanelTogglePresentation,
   buildSearchShellNotices,
   getSearchPlaceholder,
 } from "./features/browse/sidebarPresentation";
@@ -2285,31 +2287,12 @@ function BurialSidebar({
         "left-sidebar",
         "left-sidebar--desktop",
       ].join(" ");
-  const autocompleteListboxProps = isMobile
-    ? {
-      sx: {
-        maxHeight: "min(40svh, 320px)",
-        py: 0.75,
-      },
-    }
-    : {
-      sx: {
-        maxHeight: 240,
-      },
-    };
-  const autocompleteComponentsProps = useMemo(
-    () => ({
-      popper: {
-        className: "left-sidebar__autocomplete-popper",
-        placement: isMobile ? "auto-start" : "bottom-start",
-      },
-      paper: {
-        elevation: 8,
-        className: "left-sidebar__autocomplete-paper",
-      },
-    }),
+  const autocompletePresentation = useMemo(
+    () => buildAutocompletePresentation({ isMobile }),
     [isMobile]
   );
+  const autocompleteComponentsProps = autocompletePresentation.componentsProps;
+  const autocompleteListboxProps = autocompletePresentation.listboxProps;
   const selectedSectionOption = useMemo(
     () => uniqueSections.find((option) => `${option}` === `${sectionFilter}`) ?? null,
     [sectionFilter, uniqueSections]
@@ -2422,27 +2405,27 @@ function BurialSidebar({
       <MoreHorizIcon fontSize="small" />
     </IconButton>
   ) : null;
-  const isMobileSearchPanelCollapsed = isMobileSearchPanelCollapsedByControl
-    || resolvedMobileSheetState === MOBILE_SHEET_STATES.COLLAPSED;
-  const mobileSearchPanelToggleLabel = isMobileSearchPanelCollapsed
-    ? "Search"
-    : "Collapse";
+  const mobileSearchPanelTogglePresentation = useMemo(
+    () => buildMobileSearchPanelTogglePresentation({
+      collapsedSheetState: MOBILE_SHEET_STATES.COLLAPSED,
+      isMobileSearchPanelCollapsedByControl,
+      resolvedMobileSheetState,
+    }),
+    [isMobileSearchPanelCollapsedByControl, resolvedMobileSheetState]
+  );
   const mobileSearchPanelToggleButton = isMobile ? (
     <IconButton
       size="small"
       color="inherit"
       onClick={handleToggleMobileSearchPanel}
-      aria-label={mobileSearchPanelToggleLabel}
-      title={mobileSearchPanelToggleLabel}
-      aria-pressed={isMobileSearchPanelCollapsed}
+      aria-label={mobileSearchPanelTogglePresentation.label}
+      title={mobileSearchPanelTogglePresentation.label}
+      aria-pressed={mobileSearchPanelTogglePresentation.isCollapsed}
       className="mobile-sheet-header__icon-button"
     >
       <ArrowDropDownIcon
         fontSize="small"
-        sx={{
-          transform: isMobileSearchPanelCollapsed ? "rotate(180deg)" : "rotate(0deg)",
-          transition: "transform 0.2s ease",
-        }}
+        sx={mobileSearchPanelTogglePresentation.iconSx}
       />
     </IconButton>
   ) : null;

--- a/src/features/browse/sidebarPresentation.js
+++ b/src/features/browse/sidebarPresentation.js
@@ -3,6 +3,51 @@
  * out of the React component lets tests cover empty/loading/offline states
  * without rendering the full map/sidebar shell.
  */
+export const buildAutocompletePresentation = ({
+  isMobile = false,
+} = {}) => ({
+  componentsProps: {
+    popper: {
+      className: "left-sidebar__autocomplete-popper",
+      placement: isMobile ? "auto-start" : "bottom-start",
+    },
+    paper: {
+      elevation: 8,
+      className: "left-sidebar__autocomplete-paper",
+    },
+  },
+  listboxProps: isMobile
+    ? {
+      sx: {
+        maxHeight: "min(40svh, 320px)",
+        py: 0.75,
+      },
+    }
+    : {
+      sx: {
+        maxHeight: 240,
+      },
+    },
+});
+
+export const buildMobileSearchPanelTogglePresentation = ({
+  collapsedSheetState = "collapsed",
+  isMobileSearchPanelCollapsedByControl = false,
+  resolvedMobileSheetState = "",
+} = {}) => {
+  const isCollapsed = Boolean(isMobileSearchPanelCollapsedByControl)
+    || resolvedMobileSheetState === collapsedSheetState;
+
+  return {
+    iconSx: {
+      transform: isCollapsed ? "rotate(180deg)" : "rotate(0deg)",
+      transition: "transform 0.2s ease",
+    },
+    isCollapsed,
+    label: isCollapsed ? "Search" : "Collapse",
+  };
+};
+
 export const formatLocationNoticeLabel = ({
   status,
   activeStatus,

--- a/test/browseSidebarPresentation.test.js
+++ b/test/browseSidebarPresentation.test.js
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildAutocompletePresentation,
   buildBrowseEmptyActionSpecs,
   buildBrowseResultsPanelPresentation,
   buildBrowseScopeChips,
   buildLifeDatesSummary,
+  buildMobileSearchPanelTogglePresentation,
   buildSearchShellNotices,
   formatLocationNoticeLabel,
   getBrowseEmptyState,
@@ -14,6 +16,82 @@ import {
 } from "../src/features/browse/sidebarPresentation";
 
 describe("browse sidebar presentation helpers", () => {
+  test("builds autocomplete overlay presentation for desktop and mobile", () => {
+    expect(buildAutocompletePresentation({ isMobile: false })).toEqual({
+      componentsProps: {
+        popper: {
+          className: "left-sidebar__autocomplete-popper",
+          placement: "bottom-start",
+        },
+        paper: {
+          elevation: 8,
+          className: "left-sidebar__autocomplete-paper",
+        },
+      },
+      listboxProps: {
+        sx: {
+          maxHeight: 240,
+        },
+      },
+    });
+
+    expect(buildAutocompletePresentation({ isMobile: true })).toEqual({
+      componentsProps: {
+        popper: {
+          className: "left-sidebar__autocomplete-popper",
+          placement: "auto-start",
+        },
+        paper: {
+          elevation: 8,
+          className: "left-sidebar__autocomplete-paper",
+        },
+      },
+      listboxProps: {
+        sx: {
+          maxHeight: "min(40svh, 320px)",
+          py: 0.75,
+        },
+      },
+    });
+  });
+
+  test("builds mobile search-panel toggle presentation from collapse state", () => {
+    expect(buildMobileSearchPanelTogglePresentation({
+      collapsedSheetState: "collapsed",
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: "peek",
+    })).toEqual({
+      iconSx: {
+        transform: "rotate(0deg)",
+        transition: "transform 0.2s ease",
+      },
+      isCollapsed: false,
+      label: "Collapse",
+    });
+
+    expect(buildMobileSearchPanelTogglePresentation({
+      collapsedSheetState: "collapsed",
+      isMobileSearchPanelCollapsedByControl: false,
+      resolvedMobileSheetState: "collapsed",
+    })).toEqual({
+      iconSx: {
+        transform: "rotate(180deg)",
+        transition: "transform 0.2s ease",
+      },
+      isCollapsed: true,
+      label: "Search",
+    });
+
+    expect(buildMobileSearchPanelTogglePresentation({
+      collapsedSheetState: "collapsed",
+      isMobileSearchPanelCollapsedByControl: true,
+      resolvedMobileSheetState: "peek",
+    })).toMatchObject({
+      isCollapsed: true,
+      label: "Search",
+    });
+  });
+
   test("builds browse placeholders from the current browse scope", () => {
     expect(getSearchPlaceholder({
       browseSource: "section",


### PR DESCRIPTION
Move sidebar overlay presentation details into tested browse presentation helpers before promoting through the dev branch.