### PR TITLE
fix: extract selected section presentation helper

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -30,6 +30,7 @@ import {
   buildMobileSearchPanelTogglePresentation,
   buildSearchShellNotices,
   getSearchPlaceholder,
+  getSelectedSectionOption,
 } from "./features/browse/sidebarPresentation";
 import {
   buildLocationSummary,
@@ -2294,7 +2295,7 @@ function BurialSidebar({
   const autocompleteComponentsProps = autocompletePresentation.componentsProps;
   const autocompleteListboxProps = autocompletePresentation.listboxProps;
   const selectedSectionOption = useMemo(
-    () => uniqueSections.find((option) => `${option}` === `${sectionFilter}`) ?? null,
+    () => getSelectedSectionOption({ sectionFilter, uniqueSections }),
     [sectionFilter, uniqueSections]
   );
   const searchPlaceholder = getSearchPlaceholder({

--- a/src/features/browse/sidebarPresentation.js
+++ b/src/features/browse/sidebarPresentation.js
@@ -48,6 +48,13 @@ export const buildMobileSearchPanelTogglePresentation = ({
   };
 };
 
+export const getSelectedSectionOption = ({
+  sectionFilter = "",
+  uniqueSections = [],
+} = {}) => (
+  uniqueSections.find((option) => `${option}` === `${sectionFilter}`) ?? null
+);
+
 export const formatLocationNoticeLabel = ({
   status,
   activeStatus,

--- a/test/browseSidebarPresentation.test.js
+++ b/test/browseSidebarPresentation.test.js
@@ -12,6 +12,7 @@ import {
   getBrowseEmptyState,
   getLocationNoticeTone,
   getSearchPlaceholder,
+  getSelectedSectionOption,
   getSearchShellNoticeStyles,
 } from "../src/features/browse/sidebarPresentation";
 
@@ -90,6 +91,23 @@ describe("browse sidebar presentation helpers", () => {
       isCollapsed: true,
       label: "Search",
     });
+  });
+
+  test("resolves selected section options by normalized value", () => {
+    expect(getSelectedSectionOption({
+      sectionFilter: "12",
+      uniqueSections: [8, 12, 16],
+    })).toBe(12);
+
+    expect(getSelectedSectionOption({
+      sectionFilter: 8,
+      uniqueSections: ["8", "9"],
+    })).toBe("8");
+
+    expect(getSelectedSectionOption({
+      sectionFilter: "99",
+      uniqueSections: [8, 12, 16],
+    })).toBeNull();
   });
 
   test("builds browse placeholders from the current browse scope", () => {


### PR DESCRIPTION
Move selected section option resolution into the tested browse sidebar presentation helpers.