### PR TITLE
fix: extract sidebar shell presentation

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -31,6 +31,7 @@ import {
   buildSearchShellNotices,
   getSearchPlaceholder,
   getSelectedSectionOption,
+  getSidebarClassName,
 } from "./features/browse/sidebarPresentation";
 import {
   buildLocationSummary,
@@ -2282,12 +2283,7 @@ function BurialSidebar({
     setIsSelectedSummaryExpanded,
   ]);
 
-  const sidebarClassName = isMobile
-    ? "left-sidebar left-sidebar--mobile"
-    : [
-        "left-sidebar",
-        "left-sidebar--desktop",
-      ].join(" ");
+  const sidebarClassName = getSidebarClassName({ isMobile });
   const autocompletePresentation = useMemo(
     () => buildAutocompletePresentation({ isMobile }),
     [isMobile]

--- a/src/features/browse/sidebarPresentation.js
+++ b/src/features/browse/sidebarPresentation.js
@@ -55,6 +55,12 @@ export const getSelectedSectionOption = ({
   uniqueSections.find((option) => `${option}` === `${sectionFilter}`) ?? null
 );
 
+export const getSidebarClassName = ({
+  isMobile = false,
+} = {}) => (
+  isMobile ? "left-sidebar left-sidebar--mobile" : "left-sidebar left-sidebar--desktop"
+);
+
 export const formatLocationNoticeLabel = ({
   status,
   activeStatus,

--- a/test/browseSidebarPresentation.test.js
+++ b/test/browseSidebarPresentation.test.js
@@ -13,6 +13,7 @@ import {
   getLocationNoticeTone,
   getSearchPlaceholder,
   getSelectedSectionOption,
+  getSidebarClassName,
   getSearchShellNoticeStyles,
 } from "../src/features/browse/sidebarPresentation";
 
@@ -108,6 +109,11 @@ describe("browse sidebar presentation helpers", () => {
       sectionFilter: "99",
       uniqueSections: [8, 12, 16],
     })).toBeNull();
+  });
+
+  test("builds sidebar shell class names for desktop and mobile", () => {
+    expect(getSidebarClassName({ isMobile: true })).toBe("left-sidebar left-sidebar--mobile");
+    expect(getSidebarClassName({ isMobile: false })).toBe("left-sidebar left-sidebar--desktop");
   });
 
   test("builds browse placeholders from the current browse scope", () => {


### PR DESCRIPTION
Move sidebar shell class-name presentation into tested browse sidebar presentation helpers.