### PR TITLE
Polish sidebar browse controls

### DIFF
--- a/src/BurialSidebar.jsx
+++ b/src/BurialSidebar.jsx
@@ -961,12 +961,10 @@ function SelectionLeadCard({
     rows: popupView.rows,
   });
   const [mediaUrl, setMediaUrl] = useState(() => popupView.imageUrl || "");
-  const [isDetailsOpen, setIsDetailsOpen] = useState(false);
 
   useEffect(() => {
     setMediaUrl(popupView.imageUrl || "");
-    setIsDetailsOpen(false);
-  }, [popupKey, popupView.imageUrl]);
+  }, [popupView.imageUrl]);
 
   const handleImageError = useCallback(() => {
     setMediaUrl((currentUrl) => {
@@ -1090,29 +1088,14 @@ function SelectionLeadCard({
         </Box>
       </ButtonBase>
       {detailPresentation.allDetailRows.length > 0 && (
-        <>
-          <button
-            type="button"
-            className="popup-card__action popup-card__action--ghost left-sidebar__detail-toggle"
-            onClick={() => setIsDetailsOpen((prev) => !prev)}
-          >
-            {isDetailsOpen ? "Hide details" : "Show details"}
-          </button>
-          {isDetailsOpen && (
-            <Box sx={{ mt: 0.85 }}>
-              {detailPresentation.allDetailRows.length > 0 && (
-                <Box component="dl" className="left-sidebar__selected-place-facts">
-                  {detailPresentation.allDetailRows.map(({ label, value }) => (
-                    <Box key={`${popupKey}-lead-${label}`} className="left-sidebar__selected-place-fact">
-                      <dt>{label}</dt>
-                      <dd>{value}</dd>
-                    </Box>
-                  ))}
-                </Box>
-              )}
+        <Box component="dl" className="left-sidebar__selected-place-facts">
+          {detailPresentation.allDetailRows.map(({ label, value }) => (
+            <Box key={`${popupKey}-lead-${label}`} className="left-sidebar__selected-place-fact">
+              <dt>{label}</dt>
+              <dd>{value}</dd>
             </Box>
-          )}
-        </>
+          ))}
+        </Box>
       )}
       <SelectedRecordActionButtons
         burial={burial}

--- a/src/BurialSidebar.test.jsx
+++ b/src/BurialSidebar.test.jsx
@@ -308,7 +308,7 @@ describe("BurialSidebar", () => {
     );
     flushBrowseTimers();
 
-    expect(screen.getByRole("button", { name: "Explore Sections" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Sections" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByPlaceholderText(/Search this section/i)).toBeInTheDocument();
 
     const browseWorkspace = getBrowseWorkspace();
@@ -320,8 +320,8 @@ describe("BurialSidebar", () => {
     renderSidebar({ isMobile: true });
 
     expect(getCurrentMobileSheetSnap()).toBeCloseTo(390);
-    expect(screen.getByRole("button", { name: "Explore Sections" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Start a Tour" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sections" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tours" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Section" })).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Search graves & landmarks/i)).toBeInTheDocument();
     expect(screen.queryByText("Start with a section")).not.toBeInTheDocument();
@@ -714,7 +714,7 @@ describe("BurialSidebar", () => {
 
     flushBrowseTimers();
 
-    expect(screen.getByRole("button", { name: "Start a Tour" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Tours" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("combobox", { name: "Tour" })).toHaveValue("Notables Tour 2020");
 
     const tourPanel = screen.getByText(/Choose tour/i).closest(".left-sidebar__browse-detail");
@@ -733,7 +733,7 @@ describe("BurialSidebar", () => {
 
     flushBrowseTimers();
 
-    expect(screen.getByRole("button", { name: "Start a Tour" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Tours" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText(/Choose tour/i)).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Tour" })).toHaveValue("");
     expect(screen.getByPlaceholderText(/Select a tour to browse/i)).toBeInTheDocument();
@@ -750,7 +750,7 @@ describe("BurialSidebar", () => {
 
     flushBrowseTimers();
 
-    fireEvent.click(screen.getByRole("button", { name: "Explore Sections" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sections" }));
 
     expect(onTourChange).toHaveBeenCalledWith(null);
 
@@ -768,7 +768,7 @@ describe("BurialSidebar", () => {
     expect(screen.getByRole("combobox", { name: "Section" })).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Select a section to browse/i)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Explore Sections" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sections" }));
 
     expect(screen.queryByText("Choose section")).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Section" })).not.toBeInTheDocument();
@@ -783,11 +783,11 @@ describe("BurialSidebar", () => {
     expect(screen.queryByText("Results")).not.toBeInTheDocument();
     expect(screen.queryByText("Type at least 2 characters to search.")).not.toBeInTheDocument();
     expect(screen.queryByText("Start with a section")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Explore Sections" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Sections" })).toHaveAttribute("aria-pressed", "false");
 
-    fireEvent.click(screen.getByRole("button", { name: "Explore Sections" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sections" }));
 
-    expect(screen.getByRole("button", { name: "Explore Sections" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Sections" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("combobox", { name: "Section" })).toBeInTheDocument();
     expect(screen.queryByText("Results")).not.toBeInTheDocument();
   });
@@ -1215,6 +1215,8 @@ describe("BurialSidebar", () => {
 
     expect(screen.queryByText("Results")).not.toBeInTheDocument();
     expect(selectionPanel.closest(".left-sidebar__browse-workspace")).toBe(browseWorkspace);
+    expect(within(browseWorkspace).getByRole("button", { name: "Tours" })).toBeInTheDocument();
+    expect(within(browseWorkspace).getByRole("button", { name: "Sections" })).toBeInTheDocument();
   });
 
   domTest("keeps desktop selected actions visible above browse results", () => {
@@ -1234,12 +1236,16 @@ describe("BurialSidebar", () => {
     const browseWorkspace = getBrowseWorkspace();
     const selectionPanel = within(browseWorkspace).getByText("Graves at this spot").closest(".left-sidebar__panel--selected-summary");
     const searchInput = within(browseWorkspace).getByLabelText("Search burials");
+    const sectionModeButton = within(browseWorkspace).getByRole("button", { name: "Sections" });
 
     expect(selectionPanel).not.toBeNull();
     expect(within(selectionPanel).getAllByRole("button", { name: "Navigate" }).length).toBeGreaterThan(0);
     expect(selectionPanel.querySelector(".left-sidebar__selected-scroll")).not.toBeNull();
     expect(
       selectionPanel.compareDocumentPosition(searchInput) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      selectionPanel.compareDocumentPosition(sectionModeButton) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
     expect(within(browseWorkspace).getByText("8 selected")).toBeInTheDocument();
     expect(browseWorkspace).not.toBeNull();
@@ -1521,7 +1527,7 @@ describe("BurialSidebar", () => {
     expect(within(selectedSummary()).queryByText("3rd Albany Volunteers")).not.toBeInTheDocument();
   });
 
-  domTest("desktop lead card shows Show-details toggle when record has detail rows", () => {
+  domTest("desktop lead card shows detail rows without a disclosure toggle", () => {
     const richRecord = buildRichBurialRecord();
 
     renderSidebar({
@@ -1531,24 +1537,8 @@ describe("BurialSidebar", () => {
 
     const selectedPanel = getLeadSelectionCard();
 
-    expect(within(selectedPanel).getByRole("button", { name: "Show details" })).toBeInTheDocument();
-    // Detail rows should be hidden initially
-    expect(within(selectedPanel).queryByText("Mayor")).not.toBeInTheDocument();
-  });
-
-  domTest("desktop lead card toggle reveals all filtered detail rows", () => {
-    const richRecord = buildRichBurialRecord();
-
-    renderSidebar({
-      activeBurialId: richRecord.id,
-      selectedBurials: [richRecord],
-    });
-
-    const selectedPanel = getLeadSelectionCard();
-
-    fireEvent.click(within(selectedPanel).getByRole("button", { name: "Show details" }));
-
-    expect(within(selectedPanel).getByRole("button", { name: "Hide details" })).toBeInTheDocument();
+    expect(within(selectedPanel).queryByRole("button", { name: "Show details" })).not.toBeInTheDocument();
+    expect(within(selectedPanel).queryByRole("button", { name: "Hide details" })).not.toBeInTheDocument();
     expect(within(selectedPanel).getByText("Mayor")).toBeInTheDocument();
     expect(within(selectedPanel).getByText("Colonel")).toBeInTheDocument();
     expect(within(selectedPanel).getByText("1920–1924")).toBeInTheDocument();
@@ -1588,7 +1578,7 @@ describe("BurialSidebar", () => {
     expect(onFocusSelectedBurial).not.toHaveBeenCalled();
   });
 
-  domTest("desktop lead card resets to collapsed when the selected burial changes", () => {
+  domTest("desktop lead card replaces detail rows when the selected burial changes", () => {
     const richRecord = buildRichBurialRecord();
     const rerenderProps = createBaseProps();
     const { rerender } = renderSidebar({
@@ -1598,7 +1588,6 @@ describe("BurialSidebar", () => {
 
     const getLeadPanel = () => getLeadSelectionCard();
 
-    fireEvent.click(within(getLeadPanel()).getByRole("button", { name: "Show details" }));
     expect(within(getLeadPanel()).getByText("Mayor")).toBeInTheDocument();
 
     rerender(
@@ -1609,8 +1598,8 @@ describe("BurialSidebar", () => {
       />
     );
 
-    // Anna Tracy has no additional detail rows — toggle should be absent
     expect(screen.queryByRole("button", { name: "Show details" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Hide details" })).not.toBeInTheDocument();
+    expect(within(getLeadPanel()).queryByText("Mayor")).not.toBeInTheDocument();
   });
 });

--- a/src/features/browse/BrowseWorkspacePanel.jsx
+++ b/src/features/browse/BrowseWorkspacePanel.jsx
@@ -159,14 +159,12 @@ function VisitTaskSelector({
     hasTourBrowse ? {
       key: "tour",
       source: "tour",
-      ariaLabel: "Start a Tour",
       label: "Tours",
       icon: <AltRouteIcon fontSize="small" />,
     } : null,
     {
       key: "section",
       source: "section",
-      ariaLabel: "Explore Sections",
       label: "Sections",
       icon: <MapIcon fontSize="small" />,
     },
@@ -176,7 +174,7 @@ function VisitTaskSelector({
     <Box
       className="left-sidebar__visit-flow"
       role="group"
-      aria-label="Choose visit task"
+      aria-label="Browse mode"
     >
       <Box className="left-sidebar__visit-tasks">
         {taskSpecs.map((task) => {
@@ -187,7 +185,7 @@ function VisitTaskSelector({
               key={task.key}
               color="inherit"
               variant="text"
-              aria-label={task.ariaLabel}
+              aria-label={task.label}
               aria-pressed={isActive}
               className={getVisitTaskClassName(isActive)}
               onClick={() => onBrowseSourceChange(task.source)}
@@ -635,10 +633,9 @@ export default function BrowseWorkspacePanel({
   // Once a grave is selected, keep that record ahead of search and filters so
   // the sidebar follows the user's current map focus.
   const inlinePriorityContent = shouldPromotePriorityContent ? null : priorityContent;
-  // While a query is active on mobile, drop the visit-task shortcuts so results
-  // land directly under the pinned search bar, the way Maps switches modes.
-  const shouldShowVisitTasks = !shouldPromotePriorityContent
-    && !(isMobile && browseQuery.trim());
+  // While a query or selected grave owns the mobile sheet, keep shortcuts out
+  // of the way. Desktop keeps them visible so users can switch modes anytime.
+  const shouldShowVisitTasks = !(isMobile && (browseQuery.trim() || shouldPromotePriorityContent));
 
   return (
     <Box


### PR DESCRIPTION
## Summary
- keep selected-record detail rows visible without a disclosure toggle
- shorten browse mode button labels so the sidebar does not wrap awkwardly
- keep mobile shortcuts hidden when selected content owns the sheet

## Validation
- bun run check