### PR TITLE
Simplify browse scope chips

### DIFF
--- a/src/features/browse/sidebarPresentation.js
+++ b/src/features/browse/sidebarPresentation.js
@@ -426,10 +426,6 @@ export const buildBrowseScopeChips = ({
       });
     }
 
-    if (showAllBurials) {
-      chips.push({ key: "markers", label: "Markers visible" });
-    }
-
     return chips;
   }
 

--- a/test/browseSidebarPresentation.test.js
+++ b/test/browseSidebarPresentation.test.js
@@ -300,7 +300,6 @@ describe("browse sidebar presentation helpers", () => {
       showAllBurials: true,
     })).toEqual([
       { key: "detail", label: "Tier 4" },
-      { key: "markers", label: "Markers visible" },
     ]);
 
     expect(buildBrowseScopeChips({
@@ -386,7 +385,7 @@ describe("browse sidebar presentation helpers", () => {
       isBurialDataLoading: false,
       isCurrentTourLoading: false,
       query: "  Ada  ",
-      scopeChips: [{ key: "markers", label: "Markers visible" }],
+      scopeChips: [{ key: "detail", label: "Tier 4" }],
       sectionFilter: "",
       selectedTour: "",
       visibleCount: 2,


### PR DESCRIPTION
## Summary
- remove the redundant Markers visible scope chip
- keep scoped browse chip presentation focused on meaningful active filters

## Validation
- bun run check