### PR TITLE
test: expand coverage for map, browse, search worker, and runtime modules

### DIFF
--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -19,8 +19,6 @@ import "./index.css";
 import "leaflet.markercluster/dist/leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
-import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
-import { point } from "@turf/helpers";
 import {
   Menu,
   MenuItem,
@@ -133,6 +131,12 @@ import {
 } from "./features/map/mapNavigationDestination";
 import { cleanRecordValue } from "./features/map/mapRecordPresentation";
 import {
+  createRouteGeoJsonRenderKey,
+  getMapMaxZoom,
+  isLocationCandidateWithinBuffer,
+  isRenderableBounds,
+} from "./features/map/mapViewHelpers";
+import {
   PopupCardContent,
   PopupCardStackContent,
   createMapRecordKey,
@@ -203,7 +207,6 @@ const DEFAULT_VIEW_BOUNDS = APP_PROFILE.map.defaultViewBounds;
 const PADDED_BOUNDARY_BOUNDS = APP_PROFILE.map.paddedBoundaryBounds;
 const MAP_CENTER = APP_PROFILE.map.center;
 const MAP_ZOOM = APP_PROFILE.map.zoom;
-const LOCATION_BUFFER_BOUNDARY = APP_PROFILE.map.locationBufferBoundary;
 const LOCATION_MESSAGES = APP_PROFILE.map.locationMessages;
 const SLOW_CONNECTION_TYPES = new Set(['slow-2g', '2g', '3g']);
 const GEOLOCATION_REQUEST_OPTIONS = {
@@ -251,42 +254,9 @@ const DEFAULT_MAP_OVERLAY_VISIBILITY = MAP_OVERLAY_OPTIONS.reduce((visibility, o
   [option.id]: option.defaultVisible,
 }), {});
 
-const isLocationCandidateWithinBuffer = (candidate) => {
-  if (!candidate) {
-    return false;
-  }
-
-  return booleanPointInPolygon(
-    point([candidate.longitude, candidate.latitude]),
-    LOCATION_BUFFER_BOUNDARY
-  );
-};
-
-const isRenderableBounds = (bounds) => (
-  isLatLngBoundsExpressionValid(bounds) ||
-  (typeof bounds?.isValid === "function" && bounds.isValid())
-);
-
-const getMapMaxZoom = (basemap) => (
-  Number.isFinite(basemap?.maxZoom) ? basemap.maxZoom : DEFAULT_MAX_MAP_ZOOM
-);
-
 const getSectionBurialMarkerId = (burial) => {
   const properties = burial?.properties || burial || {};
   return burial?.id || properties.id || createMapRecordKey(properties);
-};
-
-const createRouteGeoJsonRenderKey = (geojson) => {
-  const coordinates = geojson?.features?.[0]?.geometry?.coordinates;
-  if (!Array.isArray(coordinates) || coordinates.length === 0) {
-    return "active-route";
-  }
-
-  return coordinates
-    .map((coordinate) => (
-      `${Number(coordinate?.[0]).toFixed(7)},${Number(coordinate?.[1]).toFixed(7)}`
-    ))
-    .join("|");
 };
 
 const createTourMarker = (tourKey, tourStyles) => {
@@ -819,7 +789,7 @@ export default function BurialMap() {
     [activeBasemapId, basemapById, defaultBasemap]
   );
   const activeBasemapMaxZoom = useMemo(
-    () => getMapMaxZoom(activeBasemap),
+    () => getMapMaxZoom(activeBasemap, DEFAULT_MAX_MAP_ZOOM),
     [activeBasemap]
   );
   const routeGeoJsonRenderKey = useMemo(
@@ -2022,7 +1992,7 @@ export default function BurialMap() {
       const currentZoom = map.getZoom();
       const targetZoom = resolvePointSelectionFocusZoom({
         currentZoom,
-        maxZoom: getMapMaxZoom(activeBasemap),
+        maxZoom: getMapMaxZoom(activeBasemap, DEFAULT_MAX_MAP_ZOOM),
         selectionSource,
         sourceFocusMinZoom: FOCUS_ZOOM_LEVEL,
       });

--- a/src/features/browse/BrowseWorkspacePanel.test.jsx
+++ b/src/features/browse/BrowseWorkspacePanel.test.jsx
@@ -1,0 +1,215 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import BrowseWorkspacePanel from "./BrowseWorkspacePanel";
+
+const noop = () => {};
+
+const baseProps = {
+  autocompleteComponentsProps: {},
+  autocompleteListboxProps: {},
+  burialDataError: null,
+  browseQuery: "",
+  filterType: "lot",
+  hasGlobalResetState: false,
+  hasSectionFilters: false,
+  hasTourBrowse: true,
+  hasTourSelection: false,
+  isBrowsePending: false,
+  isBurialDataLoading: false,
+  isMobile: false,
+  isSectionBrowseVisible: false,
+  isTourBrowseVisible: false,
+  lotTierFilter: "",
+  onBrowseQueryChange: noop,
+  onBrowseSourceChange: noop,
+  onClearAllBrowseState: noop,
+  onClearBrowseQuery: noop,
+  onClearSectionFilters: noop,
+  onClearTourSelection: noop,
+  onFilterTypeSelection: noop,
+  onLotTierChange: noop,
+  onRequestBurialDataLoad: noop,
+  onSectionSelection: noop,
+  onToggleSectionMarkers: noop,
+  onTourSelection: noop,
+  searchPlaceholder: "Search burials",
+  searchShellNotices: [],
+  sectionFilter: "",
+  selectedSectionOption: null,
+  selectedTour: null,
+  showAllBurials: false,
+  tourDefinitions: [
+    { key: "notables", name: "Notables Tour 2020" },
+    { key: "civilWar", name: "Civil War Tour 2020" },
+  ],
+  tourLabel: "Tour",
+  tourStyles: { notables: { color: "#123456" }, civilWar: { color: "#654321" } },
+  uniqueSections: ["1", "12", "100A"],
+};
+
+const renderPanel = (overrides = {}) => render(
+  <BrowseWorkspacePanel {...baseProps} {...overrides} />
+);
+
+describe("BrowseWorkspacePanel search field", () => {
+  test("renders the search field with the provided placeholder", () => {
+    renderPanel();
+    expect(screen.getByPlaceholderText("Search burials")).toBeInTheDocument();
+  });
+
+  test("hides the search field when showSearchField is false", () => {
+    renderPanel({ showSearchField: false });
+    expect(screen.queryByPlaceholderText("Search burials")).not.toBeInTheDocument();
+  });
+
+  test("forwards typing and focus to the owning callbacks", () => {
+    const onBrowseQueryChange = jest.fn();
+    const onRequestBurialDataLoad = jest.fn();
+    renderPanel({ onBrowseQueryChange, onRequestBurialDataLoad });
+
+    const input = screen.getByLabelText("Search burials");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "doe" } });
+
+    expect(onRequestBurialDataLoad).toHaveBeenCalledTimes(1);
+    expect(onBrowseQueryChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows the clear affordance only when a query is present", () => {
+    const onClearBrowseQuery = jest.fn();
+    const { rerender } = renderPanel({ browseQuery: "" });
+    expect(screen.queryByLabelText("Clear search query")).not.toBeInTheDocument();
+
+    rerender(<BrowseWorkspacePanel {...baseProps} browseQuery="doe" onClearBrowseQuery={onClearBrowseQuery} />);
+    fireEvent.click(screen.getByLabelText("Clear search query"));
+    expect(onClearBrowseQuery).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BrowseWorkspacePanel visit tasks", () => {
+  test("offers the tours task only when tour browsing is available", () => {
+    const onBrowseSourceChange = jest.fn();
+    renderPanel({ onBrowseSourceChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "Tours" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sections" }));
+
+    expect(onBrowseSourceChange).toHaveBeenNthCalledWith(1, "tour");
+    expect(onBrowseSourceChange).toHaveBeenNthCalledWith(2, "section");
+  });
+
+  test("drops the tours task when tour browsing is unavailable", () => {
+    renderPanel({ hasTourBrowse: false });
+    expect(screen.queryByRole("button", { name: "Tours" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sections" })).toBeInTheDocument();
+  });
+
+  test("hides the visit tasks on mobile while a query owns the sheet", () => {
+    renderPanel({ isMobile: true, browseQuery: "doe" });
+    expect(screen.queryByRole("button", { name: "Sections" })).not.toBeInTheDocument();
+  });
+});
+
+describe("BrowseWorkspacePanel toolbar", () => {
+  test("renders the reset action and forwards clicks when reset state exists", () => {
+    const onClearAllBrowseState = jest.fn();
+    renderPanel({ hasGlobalResetState: true, onClearAllBrowseState });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear all browse filters" }));
+    expect(onClearAllBrowseState).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits the reset action when there is nothing to reset", () => {
+    renderPanel({ hasGlobalResetState: false });
+    expect(screen.queryByRole("button", { name: "Clear all browse filters" })).not.toBeInTheDocument();
+  });
+});
+
+describe("BrowseWorkspacePanel section controls", () => {
+  test("prompts the user to choose a section before one is focused", () => {
+    renderPanel({ isSectionBrowseVisible: true });
+    expect(screen.getByText("Choose a section to zoom in.")).toBeInTheDocument();
+  });
+
+  test("exposes refinement controls once a section is focused", () => {
+    const onToggleSectionMarkers = jest.fn();
+    const onFilterTypeSelection = jest.fn();
+    const onLotTierChange = jest.fn();
+    renderPanel({
+      isSectionBrowseVisible: true,
+      sectionFilter: "12",
+      onToggleSectionMarkers,
+      onFilterTypeSelection,
+      onLotTierChange,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Show grave markers in this section" }));
+    expect(onToggleSectionMarkers).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Tier" }));
+    expect(onFilterTypeSelection).toHaveBeenCalledWith("tier");
+
+    fireEvent.change(screen.getByLabelText("Lot Number"), { target: { value: "8" } });
+    expect(onLotTierChange).toHaveBeenCalledWith("8");
+  });
+
+  test("offers a clear action when section filters are active", () => {
+    const onClearSectionFilters = jest.fn();
+    renderPanel({
+      isSectionBrowseVisible: true,
+      sectionFilter: "12",
+      hasSectionFilters: true,
+      onClearSectionFilters,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClearSectionFilters).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BrowseWorkspacePanel tour controls", () => {
+  test("renders the tour chooser when tour browsing is visible", () => {
+    renderPanel({ isTourBrowseVisible: true });
+    expect(screen.getByText("Choose tour")).toBeInTheDocument();
+    expect(
+      screen.getByText("Switch to one curated route when you want guided stops.")
+    ).toBeInTheDocument();
+  });
+
+  test("offers a clear action when a tour is selected", () => {
+    const onClearTourSelection = jest.fn();
+    renderPanel({
+      isTourBrowseVisible: true,
+      hasTourSelection: true,
+      onClearTourSelection,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(onClearTourSelection).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BrowseWorkspacePanel content slots", () => {
+  test("promotes priority content above the search composer", () => {
+    renderPanel({ priorityContent: <div data-testid="priority">Selected grave</div> });
+    expect(screen.getByTestId("priority")).toBeInTheDocument();
+  });
+
+  test("renders search shell notices", () => {
+    renderPanel({
+      searchShellNotices: [
+        { key: "loading", tone: "info", label: "Loading burial records" },
+      ],
+    });
+    expect(screen.getByText("Loading burial records")).toBeInTheDocument();
+  });
+
+  test("renders supplied results content", () => {
+    renderPanel({ resultsContent: <div data-testid="results">Results</div> });
+    expect(screen.getByTestId("results")).toBeInTheDocument();
+  });
+});

--- a/src/features/map/mapMarkerIcons.test.jsx
+++ b/src/features/map/mapMarkerIcons.test.jsx
@@ -1,0 +1,135 @@
+/** @jest-environment jsdom */
+
+import {
+  MAP_MARKER_COLORS,
+  createCemeteryClusterIcon,
+  createNumberedMarkerIcon,
+  createSelectedBurialStackIcon,
+  getSectionAffordanceIcon,
+  getSectionClusterIcon,
+  getSectionPoiIcon,
+} from "./mapMarkerIcons";
+
+describe("MAP_MARKER_COLORS", () => {
+  test("exposes a stable palette of hex colors", () => {
+    expect(MAP_MARKER_COLORS).toHaveLength(6);
+    MAP_MARKER_COLORS.forEach((color) => {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    });
+  });
+});
+
+describe("createNumberedMarkerIcon", () => {
+  test("assigns a fixed badge size and embeds the marker number", () => {
+    const icon = createNumberedMarkerIcon(1);
+
+    expect(icon.options.iconSize).toEqual([32, 32]);
+    expect(icon.options.iconAnchor).toEqual([16, 16]);
+    expect(icon.options.html).toContain('data-marker-number="1"');
+    expect(icon.options.html).toMatch(/>\s*1\s*<\/div>/);
+  });
+
+  test("cycles palette colors and wraps past the palette length", () => {
+    expect(createNumberedMarkerIcon(1).options.html).toContain(`--marker-color: ${MAP_MARKER_COLORS[0]}`);
+    expect(createNumberedMarkerIcon(2).options.html).toContain(`--marker-color: ${MAP_MARKER_COLORS[1]}`);
+    // (7 - 1) % 6 === 0 wraps back to the first palette color.
+    expect(createNumberedMarkerIcon(7).options.html).toContain(`--marker-color: ${MAP_MARKER_COLORS[0]}`);
+  });
+
+  test("caches icons by number so repeated lookups reuse one instance", () => {
+    expect(createNumberedMarkerIcon(3)).toBe(createNumberedMarkerIcon(3));
+  });
+});
+
+describe("createCemeteryClusterIcon", () => {
+  test("scales the badge with the cluster count", () => {
+    expect(createCemeteryClusterIcon({ count: 0 }).options.iconSize).toEqual([30, 30]);
+    expect(createCemeteryClusterIcon({ count: 3 }).options.iconSize).toEqual([31, 31]);
+    expect(createCemeteryClusterIcon({ count: 6 }).options.iconSize).toEqual([32, 32]);
+    expect(createCemeteryClusterIcon({ count: 10 }).options.iconSize).toEqual([34, 34]);
+    expect(createCemeteryClusterIcon({ count: 20 }).options.iconSize).toEqual([37, 37]);
+    expect(createCemeteryClusterIcon({ count: 50 }).options.iconSize).toEqual([40, 40]);
+  });
+
+  test("lets an explicit size override the count-derived size", () => {
+    expect(createCemeteryClusterIcon({ count: 50, size: 18 }).options.iconSize).toEqual([18, 18]);
+  });
+
+  test("derives a density class and accessible label from the count", () => {
+    const dense = createCemeteryClusterIcon({ count: 50 });
+    expect(dense.options.html).toContain("cemetery-cluster--massive");
+    expect(dense.options.html).toContain('data-density-label="50 or more records"');
+
+    const sparse = createCemeteryClusterIcon({ count: 1 });
+    expect(sparse.options.html).toContain("cemetery-cluster--small");
+    expect(sparse.options.html).toContain('data-density-label="1 to 2 records"');
+  });
+
+  test("escapes the rendered label to keep injected markup inert", () => {
+    const icon = createCemeteryClusterIcon({ count: 2, label: '<img src=x onerror="alert(1)">' });
+
+    expect(icon.options.html).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+    expect(icon.options.html).not.toContain("<img src=x");
+  });
+
+  test("defaults the visible label to the normalized count", () => {
+    expect(createCemeteryClusterIcon({ count: 12 }).options.html).toContain(
+      '<span class="cemetery-cluster__count">12</span>'
+    );
+  });
+});
+
+describe("createSelectedBurialStackIcon", () => {
+  test("uses the selected-stack styling at a fixed size", () => {
+    const icon = createSelectedBurialStackIcon({ count: 4 });
+
+    expect(icon.options.iconSize).toEqual([34, 34]);
+    expect(icon.options.className).toContain("selected-burial-cluster-icon");
+    expect(icon.options.html).toContain("selected-burial-cluster");
+  });
+
+  test("adds the highlighted modifier only when highlighted", () => {
+    expect(createSelectedBurialStackIcon({ count: 1, isHighlighted: true }).options.html).toContain(
+      "selected-burial-cluster--highlighted"
+    );
+    expect(createSelectedBurialStackIcon({ count: 1, isHighlighted: false }).options.html).not.toContain(
+      "selected-burial-cluster--highlighted"
+    );
+  });
+});
+
+describe("getSectionPoiIcon", () => {
+  test("renders an escaped section label and section sizing", () => {
+    const badge = 26;
+    const icon = getSectionPoiIcon({ sectionValue: "12<b>", size: badge });
+
+    expect(icon.options.iconSize).toEqual([72, badge + 18]);
+    expect(icon.options.html).toContain("Sec 12&lt;b&gt;");
+    expect(icon.options.html).not.toContain("<b>");
+  });
+
+  test("omits the label when withLabel is false", () => {
+    const icon = getSectionPoiIcon({ sectionValue: "12", withLabel: false });
+    expect(icon.options.html).not.toContain("section-poi__label");
+  });
+
+  test("caches icons by their visual signature", () => {
+    const first = getSectionPoiIcon({ sectionValue: "7", size: 26, variant: "overview" });
+    const second = getSectionPoiIcon({ sectionValue: "7", size: 26, variant: "overview" });
+    expect(first).toBe(second);
+  });
+});
+
+describe("section affordance helpers", () => {
+  test("getSectionClusterIcon renders a label-free detail marker", () => {
+    const icon = getSectionClusterIcon(5);
+    expect(icon.options.html).toContain("section-poi--detail");
+    expect(icon.options.html).not.toContain("section-poi__label");
+  });
+
+  test("getSectionAffordanceIcon renders a label-free overview marker", () => {
+    const icon = getSectionAffordanceIcon(28);
+    expect(icon.options.html).toContain("section-poi--overview");
+    expect(icon.options.html).not.toContain("section-poi__label");
+  });
+});

--- a/src/features/map/mapViewHelpers.js
+++ b/src/features/map/mapViewHelpers.js
@@ -1,0 +1,63 @@
+/**
+ * Pure view helpers extracted from `Map.jsx`. These translate raw map inputs
+ * (location candidates, basemap definitions, bounds, and route GeoJSON) into the
+ * small derived values the map component renders from. Keeping them in their own
+ * module lets the large map component stay focused on wiring while the geometry
+ * and key logic stays unit-testable without a Leaflet runtime.
+ */
+import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
+import { point } from "@turf/helpers";
+
+import { APP_PROFILE } from "../fab/profile";
+import { isLatLngBoundsExpressionValid } from "../../shared/geoJsonBounds";
+
+const LOCATION_BUFFER_BOUNDARY = APP_PROFILE.map.locationBufferBoundary;
+
+/**
+ * Reports whether a geolocation candidate falls inside the cemetery buffer.
+ * Off-site fixes are rejected so routing and recentering stay within the map.
+ */
+export const isLocationCandidateWithinBuffer = (candidate) => {
+  if (!candidate) {
+    return false;
+  }
+
+  return booleanPointInPolygon(
+    point([candidate.longitude, candidate.latitude]),
+    LOCATION_BUFFER_BOUNDARY
+  );
+};
+
+/**
+ * Accepts either a serializable bounds expression or a live Leaflet bounds
+ * object, so callers can fit the map without first normalizing the shape.
+ */
+export const isRenderableBounds = (bounds) => (
+  isLatLngBoundsExpressionValid(bounds) ||
+  (typeof bounds?.isValid === "function" && bounds.isValid())
+);
+
+/**
+ * Resolves the max zoom for a basemap, falling back to the caller-provided
+ * default when the basemap does not pin its own ceiling.
+ */
+export const getMapMaxZoom = (basemap, fallbackZoom) => (
+  Number.isFinite(basemap?.maxZoom) ? basemap.maxZoom : fallbackZoom
+);
+
+/**
+ * Builds a stable render key from a route's coordinates so React only remounts
+ * the active-route layer when the path actually changes.
+ */
+export const createRouteGeoJsonRenderKey = (geojson) => {
+  const coordinates = geojson?.features?.[0]?.geometry?.coordinates;
+  if (!Array.isArray(coordinates) || coordinates.length === 0) {
+    return "active-route";
+  }
+
+  return coordinates
+    .map((coordinate) => (
+      `${Number(coordinate?.[0]).toFixed(7)},${Number(coordinate?.[1]).toFixed(7)}`
+    ))
+    .join("|");
+};

--- a/test/appProfile.test.js
+++ b/test/appProfile.test.js
@@ -60,6 +60,69 @@ describe("app profile", () => {
     );
   });
 
+  test("resolves record image urls against the cemetery image directory", () => {
+    const { resolveImageUrl, noImageUrl } = APP_PROFILE.features.recordPresentation;
+
+    expect(resolveImageUrl("")).toBe(noImageUrl);
+    expect(resolveImageUrl("NONE")).toBe(noImageUrl);
+    expect(resolveImageUrl("Schuyler70a.jpg")).toBe(
+      "https://www.albany.edu/arce/images/Schuyler70a.jpg"
+    );
+    expect(resolveImageUrl("Schuyler70a")).toBe(
+      "https://www.albany.edu/arce/images/Schuyler70a.jpg"
+    );
+    expect(resolveImageUrl("portrait.png")).toBe(
+      "https://www.albany.edu/arce/images/portrait.png"
+    );
+  });
+
+  test("builds profile-owned popup rows from cemetery source fields", () => {
+    const { buildPopupRows } = APP_PROFILE.features.recordPresentation;
+
+    const rows = buildPopupRows(
+      {
+        Titles: "Mayor",
+        Highest_Ra: "Colonel",
+        Initial_Te: "1850",
+        Subsequent: "1852",
+        Unit: "10th NY",
+        Headstone_: "marble",
+        Service_Re: "Union Army",
+      },
+      {
+        buildLocationSummary: () => "Section 12, Lot 8",
+        resolveRecordDates: () => ({ birth: "1812", death: "1899" }),
+      }
+    );
+
+    const rowMap = Object.fromEntries(rows.map(({ label, value }) => [label, value]));
+
+    expect(rowMap.Role).toBe("Mayor");
+    expect(rowMap.Rank).toBe("Colonel");
+    expect(rowMap["Initial term"]).toBe("1850");
+    expect(rowMap["Subsequent term"]).toBe("1852");
+    expect(rowMap.Unit).toBe("10th NY");
+    expect(rowMap.Location).toBe("Section 12, Lot 8");
+    expect(rowMap.Born).toBe("1812");
+    expect(rowMap.Died).toBe("1899");
+    expect(rowMap.Headstone).toBe("Headstone marble");
+    expect(rowMap.Service).toBe("Union Army");
+  });
+
+  test("omits empty popup rows and avoids duplicating the rank label", () => {
+    const { buildPopupRows } = APP_PROFILE.features.recordPresentation;
+
+    const rows = buildPopupRows({
+      Titles: "Captain",
+      Highest_Ra: "Captain",
+      Headstone_: "Headstone present",
+    });
+    const labels = rows.map((row) => row.label);
+
+    expect(labels).toEqual(["Role", "Headstone"]);
+    expect(rows.find((row) => row.label === "Headstone").value).toBe("Headstone present");
+  });
+
   test("exposes the iPhone app listing used by shared-link install prompts", () => {
     expect(APP_PROFILE.distribution.iosAppStoreUrl).toBe(
       "https://apps.apple.com/us/app/albany-grave-finder/id6746413050"

--- a/test/browseSearchWorker.test.js
+++ b/test/browseSearchWorker.test.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+// The worker module wires itself onto the global scope on import: it assigns
+// `globalThis.onmessage` and posts results back through `globalThis.postMessage`.
+// These tests drive that message protocol directly without spawning a Worker.
+import "../src/features/browse/browseSearch.worker";
+
+const RECORDS = [
+  {
+    id: 1,
+    First_Name: "Jane",
+    Last_Name: "Doe",
+    Section: "12",
+    Lot: "8",
+    Birth: "1812",
+    Death: "1899",
+    searchableLabel: "Jane Doe (Section 12, Lot 8)",
+    searchableLabelLower: "jane doe (section 12, lot 8)",
+    nameVariantsNormalized: ["jane doe", "doe jane"],
+  },
+  {
+    id: 2,
+    First_Name: "John",
+    Last_Name: "Smith",
+    Section: "3",
+    Lot: "12",
+    Birth: "1820",
+    Death: "1888",
+    searchableLabel: "John Smith (Section 3, Lot 12)",
+    searchableLabelLower: "john smith (section 3, lot 12)",
+    tourName: "Notables Tour 2020",
+  },
+];
+
+let posted = [];
+let originalPostMessage;
+
+const dispatch = (data) => {
+  globalThis.onmessage({ data });
+};
+
+const hydrate = (recordVersion = 1, records = RECORDS) => {
+  dispatch({ type: "hydrate", recordVersion, records });
+};
+
+beforeEach(() => {
+  posted = [];
+  originalPostMessage = globalThis.postMessage;
+  globalThis.postMessage = (message) => {
+    posted.push(message);
+  };
+});
+
+afterEach(() => {
+  globalThis.postMessage = originalPostMessage;
+});
+
+describe("browseSearch worker protocol", () => {
+  test("acknowledges hydration with a ready message for the active record version", () => {
+    hydrate(7);
+
+    expect(posted).toEqual([{ type: "ready", recordVersion: 7 }]);
+  });
+
+  test("returns matching record ids for a query against the active version", () => {
+    hydrate(2);
+    posted = [];
+
+    dispatch({ type: "query", requestId: "abc", recordVersion: 2, query: "jane doe" });
+
+    expect(posted).toEqual([
+      { type: "results", requestId: "abc", recordVersion: 2, resultIds: [1] },
+    ]);
+  });
+
+  test("resolves tour-name queries through the worker tour-name accessor", () => {
+    hydrate(3);
+    posted = [];
+
+    dispatch({ type: "query", requestId: "tour", recordVersion: 3, query: "notables tour" });
+
+    expect(posted).toEqual([
+      { type: "results", requestId: "tour", recordVersion: 3, resultIds: [2] },
+    ]);
+  });
+
+  test("reports a stale response when the query targets an outdated version", () => {
+    hydrate(5);
+    posted = [];
+
+    dispatch({ type: "query", requestId: "old", recordVersion: 4, query: "jane" });
+
+    expect(posted).toEqual([{ type: "stale", requestId: "old", recordVersion: 4 }]);
+  });
+
+  test("treats hydration as version control: a tolerant query still matches", () => {
+    hydrate(9);
+    posted = [];
+
+    dispatch({ type: "query", requestId: "section", recordVersion: 9, query: "section 12" });
+
+    expect(posted).toEqual([
+      { type: "results", requestId: "section", recordVersion: 9, resultIds: [1] },
+    ]);
+  });
+
+  test("ignores unrelated message types without posting back", () => {
+    hydrate(1);
+    posted = [];
+
+    dispatch({ type: "noop" });
+
+    expect(posted).toEqual([]);
+  });
+
+  test("posts an error message when handling a malformed event throws", () => {
+    dispatch({
+      get type() {
+        throw new Error("boom");
+      },
+      requestId: "broken",
+      recordVersion: 1,
+    });
+
+    expect(posted).toEqual([
+      { type: "error", requestId: "broken", recordVersion: 1, error: "boom" },
+    ]);
+  });
+});

--- a/test/burialSearch.test.js
+++ b/test/burialSearch.test.js
@@ -114,4 +114,34 @@ describe('smartSearch without index', () => {
     const results = smartSearch(options, 'lovelace', { getTourName });
     expect(results.map((item) => item.OBJECTID)).toEqual([3]);
   });
+
+  test('returns an empty list for blank input', () => {
+    expect(smartSearch(options, '   ')).toEqual([]);
+    expect(smartSearch(options, '')).toEqual([]);
+  });
+
+  test('falls back to scanning birth and death years', () => {
+    const results = smartSearch(options, '1812');
+    expect(results.map((item) => item.OBJECTID).sort()).toEqual([1, 2]);
+  });
+
+  test('falls back to scanning section values', () => {
+    const results = smartSearch(options, 'section 12');
+    expect(results.map((item) => item.OBJECTID)).toEqual([1]);
+  });
+
+  test('falls back to scanning lot values', () => {
+    const results = smartSearch(options, 'lot 9');
+    expect(results.map((item) => item.OBJECTID)).toEqual([3]);
+  });
+
+  test('falls back to scanning tour names against the whole pool', () => {
+    const results = smartSearch(options, 'civil war tour', { getTourName });
+    expect(results.map((item) => item.OBJECTID)).toEqual([3]);
+  });
+
+  test('treats a bare number as a section, lot, or year union', () => {
+    const results = smartSearch(options, '12');
+    expect(results.map((item) => item.OBJECTID).sort()).toEqual([1, 2]);
+  });
 });

--- a/test/mapViewHelpers.test.js
+++ b/test/mapViewHelpers.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import { APP_PROFILE } from "../src/features/fab/profile";
+import {
+  createRouteGeoJsonRenderKey,
+  getMapMaxZoom,
+  isLocationCandidateWithinBuffer,
+  isRenderableBounds,
+} from "../src/features/map/mapViewHelpers";
+
+const BUFFER_BOUNDARY = APP_PROFILE.map.locationBufferBoundary;
+
+// Derive an in-buffer point from the boundary polygon so the fixture tracks the
+// shipped cemetery extent instead of a hardcoded coordinate that could drift.
+const firstBoundaryRing = BUFFER_BOUNDARY.geometry.coordinates[0];
+const ringAverage = firstBoundaryRing.reduce(
+  (acc, [longitude, latitude]) => ({
+    longitude: acc.longitude + longitude / firstBoundaryRing.length,
+    latitude: acc.latitude + latitude / firstBoundaryRing.length,
+  }),
+  { longitude: 0, latitude: 0 }
+);
+
+describe("isLocationCandidateWithinBuffer", () => {
+  test("returns false for a missing candidate", () => {
+    expect(isLocationCandidateWithinBuffer(null)).toBe(false);
+    expect(isLocationCandidateWithinBuffer(undefined)).toBe(false);
+  });
+
+  test("accepts a point inside the cemetery buffer", () => {
+    expect(isLocationCandidateWithinBuffer(ringAverage)).toBe(true);
+  });
+
+  test("rejects a point far outside the cemetery buffer", () => {
+    expect(isLocationCandidateWithinBuffer({ latitude: 0, longitude: 0 })).toBe(false);
+    expect(isLocationCandidateWithinBuffer({ latitude: 51.5, longitude: -0.12 })).toBe(false);
+  });
+});
+
+describe("isRenderableBounds", () => {
+  test("accepts a valid bounds expression", () => {
+    expect(isRenderableBounds([[42.7, -73.7], [42.71, -73.69]])).toBe(true);
+  });
+
+  test("accepts a live bounds object that reports itself valid", () => {
+    expect(isRenderableBounds({ isValid: () => true })).toBe(true);
+  });
+
+  test("rejects an invalid bounds object", () => {
+    expect(isRenderableBounds({ isValid: () => false })).toBe(false);
+  });
+
+  test("rejects null and malformed bounds", () => {
+    expect(isRenderableBounds(null)).toBe(false);
+    expect(isRenderableBounds([[42.7]])).toBe(false);
+    expect(isRenderableBounds({})).toBe(false);
+  });
+});
+
+describe("getMapMaxZoom", () => {
+  test("prefers a finite basemap maxZoom", () => {
+    expect(getMapMaxZoom({ maxZoom: 22 }, 18)).toBe(22);
+    expect(getMapMaxZoom({ maxZoom: 0 }, 18)).toBe(0);
+  });
+
+  test("falls back when the basemap omits a numeric maxZoom", () => {
+    expect(getMapMaxZoom(null, 18)).toBe(18);
+    expect(getMapMaxZoom({}, 19)).toBe(19);
+    expect(getMapMaxZoom({ maxZoom: "20" }, 19)).toBe(19);
+    expect(getMapMaxZoom({ maxZoom: Infinity }, 19)).toBe(19);
+  });
+});
+
+describe("createRouteGeoJsonRenderKey", () => {
+  test("returns a stable fallback when there are no coordinates", () => {
+    expect(createRouteGeoJsonRenderKey(null)).toBe("active-route");
+    expect(createRouteGeoJsonRenderKey({})).toBe("active-route");
+    expect(createRouteGeoJsonRenderKey({ features: [] })).toBe("active-route");
+    expect(createRouteGeoJsonRenderKey({
+      features: [{ geometry: { coordinates: [] } }],
+    })).toBe("active-route");
+  });
+
+  test("encodes coordinates to a fixed precision joined key", () => {
+    expect(createRouteGeoJsonRenderKey({
+      features: [{
+        geometry: {
+          coordinates: [
+            [-73.123456789, 42.987654321],
+            [-73.2, 42.8],
+          ],
+        },
+      }],
+    })).toBe("-73.1234568,42.9876543|-73.2000000,42.8000000");
+  });
+
+  test("changes the key when the path changes", () => {
+    const build = (lng) => createRouteGeoJsonRenderKey({
+      features: [{ geometry: { coordinates: [[lng, 42.8]] } }],
+    });
+
+    expect(build(-73.2)).not.toBe(build(-73.3));
+  });
+});

--- a/test/runtimeEnv.test.js
+++ b/test/runtimeEnv.test.js
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildPublicAssetUrl,
+  cancelIdleTask,
   getRuntimeEnv,
   isFieldPacketsEnabled,
   RUNTIME_FEATURE_FLAGS,
+  scheduleIdleTask,
+  setDocumentMetaContent,
   syncDocumentMetadata,
 } from "../src/shared/runtimeEnv";
 
@@ -85,6 +89,108 @@ describe("getRuntimeEnv", () => {
   test("normalizes missing field-packet flag values", () => {
     expect(isFieldPacketsEnabled({})).toBe(true);
     expect(isFieldPacketsEnabled({ fieldPackets: false })).toBe(false);
+  });
+});
+
+describe("buildPublicAssetUrl", () => {
+  test("prefixes the deploy base path and normalizes the leading slash", () => {
+    expect(buildPublicAssetUrl("data/Search_Burials.json", "/fab")).toBe(
+      "/fab/data/Search_Burials.json"
+    );
+    expect(buildPublicAssetUrl("/data/Search_Burials.json", "/fab")).toBe(
+      "/fab/data/Search_Burials.json"
+    );
+  });
+
+  test("serves from origin root when no public url is configured", () => {
+    expect(buildPublicAssetUrl("basemaps/overview.jpg", "")).toBe("/basemaps/overview.jpg");
+    expect(buildPublicAssetUrl(null, "")).toBe("/");
+  });
+});
+
+describe("scheduleIdleTask / cancelIdleTask", () => {
+  test("returns null when no callback is provided", () => {
+    expect(scheduleIdleTask(null)).toBeNull();
+    expect(scheduleIdleTask("not a function")).toBeNull();
+  });
+
+  test("falls back to a timeout when requestIdleCallback is unavailable", async () => {
+    let invoked = false;
+    const handle = scheduleIdleTask(() => {
+      invoked = true;
+    }, { fallbackDelay: 1 });
+
+    expect(handle).toMatchObject({ type: "timeout" });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(invoked).toBe(true);
+  });
+
+  test("cancelIdleTask clears a pending timeout before it fires", async () => {
+    let invoked = false;
+    const handle = scheduleIdleTask(() => {
+      invoked = true;
+    }, { fallbackDelay: 20 });
+
+    cancelIdleTask(handle);
+    cancelIdleTask(null);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(invoked).toBe(false);
+  });
+
+  test("prefers requestIdleCallback when the runtime exposes it", () => {
+    const originalWindow = globalThis.window;
+    let scheduledCallback = null;
+    let cancelledId = null;
+
+    globalThis.window = {
+      requestIdleCallback: (callback) => {
+        scheduledCallback = callback;
+        return 42;
+      },
+      cancelIdleCallback: (id) => {
+        cancelledId = id;
+      },
+    };
+
+    try {
+      let invoked = false;
+      const handle = scheduleIdleTask(() => {
+        invoked = true;
+      });
+
+      expect(handle).toEqual({ type: "idle", id: 42 });
+      scheduledCallback();
+      expect(invoked).toBe(true);
+
+      cancelIdleTask(handle);
+      expect(cancelledId).toBe(42);
+    } finally {
+      if (originalWindow === undefined) {
+        delete globalThis.window;
+      } else {
+        globalThis.window = originalWindow;
+      }
+    }
+  });
+});
+
+describe("setDocumentMetaContent", () => {
+  test("does nothing when no document is available", () => {
+    expect(() => setDocumentMetaContent('meta[name="description"]', "x")).not.toThrow();
+  });
+
+  test("updates a matching meta element's content attribute", () => {
+    const node = createMetaNode();
+    const metadataDocument = {
+      querySelector: (selector) => (selector === 'meta[name="description"]' ? node : null),
+    };
+
+    setDocumentMetaContent('meta[name="description"]', "Hello", metadataDocument);
+    expect(node.getAttribute("content")).toBe("Hello");
+
+    expect(() => (
+      setDocumentMetaContent('meta[name="missing"]', "ignored", metadataDocument)
+    )).not.toThrow();
   });
 });
 


### PR DESCRIPTION
Superseded by #36, which re-targets the normal `feature/ → dev` flow so it satisfies the branch-naming policy. Same commit; code CI (lint, test, release metadata, shell drift) passed here — only the `claude/` branch-name gate failed.

https://claude.ai/code/session_018dPupX5weUDwByTYCnjNXZ