### PR TITLE
Seed CI/CD orchestration on main

### DIFF
--- a/.github/workflows/promote-dev-to-staging.yml
+++ b/.github/workflows/promote-dev-to-staging.yml
@@ -1,0 +1,108 @@
+name: Promote Dev to Staging
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - dev
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: promote-dev-to-staging
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    name: Open or auto-merge staging promotion
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'dev'
+      )
+
+    steps:
+      - name: Ensure dev has changes for staging
+        id: trees
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          dev_tree="$(gh api "repos/${GH_REPO}/commits/dev" --jq '.commit.tree.sha')"
+          staging_tree="$(gh api "repos/${GH_REPO}/commits/staging" --jq '.commit.tree.sha')"
+
+          if [ "$dev_tree" = "$staging_tree" ]; then
+            echo "Dev and staging already have matching trees."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open staging promotion PR and enable auto-merge
+        if: steps.trees.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          body_file="$(mktemp)"
+          cat > "$body_file" <<'BODY'
+          ## Summary
+
+          Automated promotion from `dev` to `staging` after the `dev` CI run passed.
+
+          This PR is auto-merge enabled. Close it if staging should intentionally hold.
+
+          ## Validation
+
+          - CI must pass on this promotion PR before auto-merge.
+
+          ## Release impact
+
+          - No version bump needed
+
+          ## Deployment and contracts
+
+          - No production deploy occurs from `staging`; production GitHub Pages deploys only after `staging` is promoted to `main`.
+          BODY
+
+          pr_number="$(gh pr list \
+            --base staging \
+            --head dev \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')"
+
+          if [ -z "$pr_number" ]; then
+            pr_url="$(gh pr create \
+              --base staging \
+              --head dev \
+              --title "Promote dev to staging" \
+              --body-file "$body_file")"
+            pr_number="${pr_url##*/}"
+            echo "Created promotion PR #${pr_number}."
+          else
+            gh pr edit "$pr_number" \
+              --title "Promote dev to staging" \
+              --body-file "$body_file"
+            echo "Updated existing promotion PR #${pr_number}."
+          fi
+
+          gh pr merge "$pr_number" \
+            --auto \
+            --squash \
+            --subject "Promote dev to staging" \
+            --body "Automated promotion from dev to staging after CI passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,13 +88,14 @@ If you change runtime/profile wiring:
 - `bun run start`: dev startup wrapper, alias refresh, image server, React dev server
 - `bun run test`: Bun unit tests plus Jest DOM tests
 - `bun run check`: doctor plus the default automated test suite
-- `bun run deploy`: production build plus GitHub Pages publish
+- `bun run deploy`: local production build check; GitHub Actions deploys `main`
 
 ## Contributor priorities
 
 - Keep moves additive when possible. The worktree may contain in-flight architecture cleanup already.
-- Keep active development on short-lived branches, merge through `dev`, validate
-  on `staging`, and promote `staging` to `main`.
+- Keep active development on short-lived branches, merge through `dev`, let
+  GitHub Actions auto-promote green `dev` builds to `staging`, and manually
+  promote `staging` to `main`.
 - Treat FABFG alignment as shared-contract work first and wrapper-specific work second.
 - Favor clearer Apple-HIG-inspired interaction patterns over decorative UI churn: safer spacing, fewer gestures, stronger hierarchy, and obvious states.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ Common commands:
 - `bun run pr:check`: verify pull request branch policy when GitHub provides PR context
 - `bun run build:data`: regenerate search data, tour matches, and generated
   bounds
-- `bun run deploy`: build and publish the GitHub Pages deployment
+- `bun run deploy`: create a local production build; GitHub Actions deploys
+  `main`
 
 Development work starts on short-lived branches and enters the shared pipeline
 through `dev`; see [docs/dev-branch-workflow.md](./docs/dev-branch-workflow.md).
@@ -56,7 +57,9 @@ through `dev`; see [docs/dev-branch-workflow.md](./docs/dev-branch-workflow.md).
 ## Branches and releases
 
 Use short-lived work branches for product changes. Open those branches into
-`dev`, promote `dev` to `staging`, and promote `staging` to `main`.
+`dev`; after `dev` CI passes, GitHub Actions opens or updates a `dev` ->
+`staging` PR and enables auto-merge. Promote `staging` to `main` manually when
+the public GitHub Pages/native-wrapper surface is ready.
 Short-lived branches should use `codex/`, `feature/`, `fix/`, `docs/`,
 `chore/`, `hotfix/`, `dependabot/`, or `renovate/`. Release branches may target
 `staging`; emergency hotfix branches may target `staging` or `main`.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Useful overrides:
 - `bun run release:check`: verify SemVer, changelog, and release tag metadata
 - `bun run pr:check`: verify pull request branch policy when GitHub provides PR context
 - `bun run build`: create a production build
-- `bun run deploy`: build and publish the GitHub Pages deployment
+- `bun run deploy`: create a local production build; GitHub Actions deploys
+  `main`
 - `bun run build:tour-data`: regenerate tour biography aliases
 - `bun run build:basemaps`: refresh checked-in NYS ortho basemap images
 - `bun run build:data`: regenerate search data, tour matches, and generated map
@@ -155,19 +156,22 @@ Most contributors usually need `bun run start`, `bun run test`, and
 `bun run lint`. Run `bun run doctor` when setting up the repo or when a local
 command fails unexpectedly.
 
-Maintainer, data, and deploy work uses the more specialized commands:
+Maintainer, data, and release work uses the more specialized commands:
 `bun run check`, `bun run build:data`, `bun run build:tour-data`,
 `bun run build:geoparquet`, `bun run validate:geoparquet`, `bun run build`,
-`bun run release:check`, `bun run deploy`, and the Playwright or mobile smoke
-commands when release coverage is needed.
+`bun run release:check`, and the Playwright or mobile smoke commands when
+release coverage is needed. Production deploys happen through GitHub Actions
+after `staging` is promoted to `main`.
 
 ## Branches and Releases
 
 Production work flows through three long-lived branches: `dev` for integration,
 `staging` for pre-production validation, and `main` for production. Open
-short-lived work branches into `dev`, promote `dev` to `staging`, then promote
-`staging` to `main`. Short-lived branches should use prefixes such as
-`feature/`, `fix/`, `docs/`, `chore/`, `hotfix/`, or `codex/`.
+short-lived work branches into `dev`; when `dev` CI passes, GitHub Actions opens
+or updates a `dev` -> `staging` PR and enables auto-merge. Promote `staging` to
+`main` manually when ready for the public GitHub Pages/native-wrapper surface.
+Short-lived branches should use prefixes such as `feature/`, `fix/`, `docs/`,
+`chore/`, `hotfix/`, or `codex/`.
 
 Versioned releases use SemVer in [`package.json`](./package.json), matching
 entries in [`CHANGELOG.md`](./CHANGELOG.md), and tags named `vX.Y.Z`. See
@@ -241,9 +245,9 @@ Common entry points:
 
 There are two relevant hosted environments:
 
-- GitHub Pages is the repo-controlled public validation target. Use
-  `bun run deploy` for manual fallback deploys; pushes to `main` also build
-  and deploy through GitHub Actions.
+- GitHub Pages is the repo-controlled public web deployment. It is built and
+  deployed by GitHub Actions after `staging` is manually promoted to `main`.
+  The `gh-pages` branch is not part of the normal deployment path.
 - `albany.edu/arce` is the institutional production deployment. Promotion to
   that host is still manual.
 

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,6 @@
         "@babel/preset-react": "^7.26.3",
         "@playwright/test": "^1.59.1",
         "babel-jest": "^29.7.0",
-        "gh-pages": "^6.3.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "jest-environment-jsdom": "^27.5.1",
@@ -706,7 +705,7 @@
 
     "ast-types-flow": ["ast-types-flow@0.0.7", "", {}, "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="],
 
-    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+    "async": ["async@2.6.3", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha1-x57Zf380y48robyXkLzDZkdLS3k="],
 
@@ -840,7 +839,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "common-path-prefix": ["common-path-prefix@3.0.0", "", {}, "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w=="],
 
@@ -1016,8 +1015,6 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.101", "", {}, "sha512-L0ISiQrP/56Acgu4/i/kfPwWSgrzYZUnQrC0+QPFuhqlLP1Ir7qzPPDVS9BcKIyWTRU8+o6CC8dKw38tSWhYIA=="],
 
-    "email-addresses": ["email-addresses@5.0.0", "", {}, "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw=="],
-
     "emittery": ["emittery@0.8.1", "", {}, "sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -1126,10 +1123,6 @@
 
     "filelist": ["filelist@1.0.2", "", { "dependencies": { "minimatch": "^3.0.4" } }, "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ=="],
 
-    "filename-reserved-regex": ["filename-reserved-regex@2.0.0", "", {}, "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ=="],
-
-    "filenamify": ["filenamify@4.3.0", "", { "dependencies": { "filename-reserved-regex": "^2.0.0", "strip-outer": "^1.0.1", "trim-repeated": "^1.0.0" } }, "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg=="],
-
     "filesize": ["filesize@8.0.7", "", {}, "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ=="],
 
     "fill-range": ["fill-range@7.0.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ=="],
@@ -1160,7 +1153,7 @@
 
     "fresh": ["fresh@0.5.2", "", {}, "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="],
 
-    "fs-extra": ["fs-extra@11.3.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew=="],
+    "fs-extra": ["fs-extra@10.0.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag=="],
 
     "fs-monkey": ["fs-monkey@1.0.3", "", {}, "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="],
 
@@ -1185,8 +1178,6 @@
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "get-symbol-description": ["get-symbol-description@1.0.0", "", { "dependencies": { "call-bind": "^1.0.2", "get-intrinsic": "^1.1.1" } }, "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw=="],
-
-    "gh-pages": ["gh-pages@6.3.0", "", { "dependencies": { "async": "^3.2.4", "commander": "^13.0.0", "email-addresses": "^5.0.0", "filenamify": "^4.3.0", "find-cache-dir": "^3.3.1", "fs-extra": "^11.1.1", "globby": "^11.1.0" }, "bin": { "gh-pages": "bin/gh-pages.js", "gh-pages-clean": "bin/gh-pages-clean.js" } }, "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA=="],
 
     "glob": ["glob@7.2.0", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.0.4", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q=="],
 
@@ -2040,8 +2031,6 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "strip-outer": ["strip-outer@1.0.1", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg=="],
-
     "style-loader": ["style-loader@3.3.1", "", { "peerDependencies": { "webpack": "^5.0.0" } }, "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="],
 
     "stylehacks": ["stylehacks@5.1.0", "", { "dependencies": { "browserslist": "^4.16.6", "postcss-selector-parser": "^6.0.4" }, "peerDependencies": { "postcss": "^8.2.15" } }, "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q=="],
@@ -2093,8 +2082,6 @@
     "tough-cookie": ["tough-cookie@4.0.0", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.1.2" } }, "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg=="],
 
     "tr46": ["tr46@2.1.0", "", { "dependencies": { "punycode": "^2.1.1" } }, "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw=="],
-
-    "trim-repeated": ["trim-repeated@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg=="],
 
     "tryer": ["tryer@1.0.1", "", {}, "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="],
 
@@ -2430,8 +2417,6 @@
 
     "hpack.js/readable-stream": ["readable-stream@2.3.7", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw=="],
 
-    "html-minifier-terser/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
     "htmlparser2/domutils": ["domutils@2.8.0", "", { "dependencies": { "dom-serializer": "^1.0.1", "domelementtype": "^2.2.0", "domhandler": "^4.2.0" } }, "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A=="],
 
     "http-errors/inherits": ["inherits@2.0.3", "", {}, "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="],
@@ -2494,8 +2479,6 @@
 
     "pkg-up/find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
 
-    "portfinder/async": ["async@2.6.3", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg=="],
-
     "portfinder/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "postcss-loader/semver": ["semver@7.3.5", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": "bin/semver.js" }, "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ=="],
@@ -2517,8 +2500,6 @@
     "react-dev-utils/loader-utils": ["loader-utils@3.2.0", "", {}, "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="],
 
     "react-scripts/babel-jest": ["babel-jest@27.5.1", "", { "dependencies": { "@jest/transform": "^27.5.1", "@jest/types": "^27.5.1", "@types/babel__core": "^7.1.14", "babel-plugin-istanbul": "^6.1.1", "babel-preset-jest": "^27.5.1", "chalk": "^4.0.0", "graceful-fs": "^4.2.9", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.8.0" } }, "sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg=="],
-
-    "react-scripts/fs-extra": ["fs-extra@10.0.1", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag=="],
 
     "react-scripts/semver": ["semver@7.3.5", "", { "dependencies": { "lru-cache": "^6.0.0" }, "bin": "bin/semver.js" }, "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ=="],
 
@@ -2554,8 +2535,6 @@
 
     "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "strip-outer/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="],
-
     "svgo/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "svgo/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": "bin/js-yaml.js" }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
@@ -2569,8 +2548,6 @@
     "terser-webpack-plugin/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "tough-cookie/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
-
-    "trim-repeated/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="],
 
     "tsconfig-paths/json5": ["json5@1.0.1", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": "lib/cli.js" }, "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow=="],
 

--- a/docs/dev-branch-workflow.md
+++ b/docs/dev-branch-workflow.md
@@ -6,7 +6,9 @@ links, and deployable static assets. The old `master` branch has been retired
 in favor of `main`.
 
 `staging` is the pre-production branch. It should mirror what is ready for final
-validation before production deploy.
+validation before production deploy. GitHub Actions opens or updates the
+`dev` -> `staging` promotion PR after `dev` CI passes and enables auto-merge on
+that promotion PR once its required checks pass.
 
 `dev` is the integration branch for validated work that is not yet promoted to
 staging.
@@ -27,11 +29,11 @@ git switch -c feature/short-description
 Open pull requests in this order:
 
 1. `feature/*`, `fix/*`, `docs/*`, `chore/*`, `codex/*` -> `dev`
-2. `dev` -> `staging`
-3. `staging` -> `main`
+2. `dev` -> `staging` through the generated auto-merge promotion PR
+3. `staging` -> `main` manually after final validation
 
-`gh-pages` is only the GitHub Pages deployment output branch. It is not a
-development, staging, or production source branch.
+GitHub Pages deploys from the `main` branch build through GitHub Actions. The
+legacy `gh-pages` branch is not part of the normal deployment path.
 
 ## Promoting work back
 
@@ -45,6 +47,8 @@ Promote code only when it is part of the shipped app. Keep those PRs focused:
   changes
 - follow [`release-workflow.md`](./release-workflow.md) for version, changelog,
   branch-policy, and CI/CD requirements
+- keep `staging` -> `main` as the manual gate for public GitHub Pages and
+  native-wrapper-facing changes
 
 Do not keep main-side feature flags, query params, routes, scripts, or
 dependencies solely to make dev-only tools reachable. A short-lived branch is

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -13,6 +13,9 @@ retired.
 - Use short-lived branches named `codex/*`, `feature/*`, `fix/*`, `docs/*`,
   `chore/*`, or `hotfix/*`.
 - Promote in order: short-lived branch -> `dev` -> `staging` -> `main`.
+- `dev` -> `staging` promotion is automated after green `dev` CI by
+  `.github/workflows/promote-dev-to-staging.yml`; close the generated PR if
+  staging should intentionally hold.
 - Allow `release/*` branches into `staging` for release preparation.
 - Allow `hotfix/*` branches into `staging` or `main` for emergency production
   fixes.
@@ -41,8 +44,9 @@ promotes it.
 2. Make the smallest coherent production change, including tests and docs.
 3. Run `bun run check` locally for cross-cutting work.
 4. Open a pull request into `dev`.
-5. Promote `dev` to `staging` after the integration checks pass.
-6. Promote `staging` to `main` after final validation.
+5. After `dev` CI passes, GitHub Actions opens or updates a `dev` -> `staging`
+   PR and enables auto-merge once that promotion PR's required checks pass.
+6. Promote `staging` to `main` manually after final validation.
 7. CI runs lint, tests, generated-shell drift, release metadata, and branch
    policy checks.
 8. Merge after the required checks pass.
@@ -51,7 +55,8 @@ promotes it.
 
 GitHub Actions then:
 
-- deploys `main` to GitHub Pages from a reproducible build;
+- deploys `main` to GitHub Pages from a reproducible build using the official
+  Pages artifact workflow;
 - validates release tags with `bun run release:check`;
 - creates a GitHub Release for SemVer tags.
 
@@ -73,6 +78,7 @@ For `staging`, require:
 - pull requests from `dev`, `release/*`, or `hotfix/*`
 - the same status checks as `main`
 - linear history, conversation resolution, no force pushes, and no deletions
+- auto-merge may be enabled for the generated `dev` -> `staging` promotion PR
 
 For `dev`, require:
 

--- a/docs/repo-cleanup-plan.md
+++ b/docs/repo-cleanup-plan.md
@@ -154,9 +154,11 @@ manual.
       fail on `git diff --exit-code public/index.html public/manifest.json`.
 - [x] `deploy.yml` on push to main: replace the manual
       `deploy-production.sh` / gh-pages flow with the official GitHub Pages
-      actions, so deploys are reproducible and don't depend on one laptop.
-      Keep the shell script for emergencies until the workflow has shipped a
-      few times, then delete it.
+      actions, so deploys are reproducible and don't depend on one laptop. The
+      shell script now performs a local production build check only.
+- [x] `promote-dev-to-staging.yml`: after a successful `dev` push CI run, open
+      or update the `dev` -> `staging` PR and enable auto-merge once the
+      promotion PR checks pass.
 - [x] `release.yml` on `v*.*.*` tags: validate package/changelog/tag metadata,
       build the production app, and create a GitHub Release.
 

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "@babel/preset-react": "^7.26.3",
     "@playwright/test": "^1.59.1",
     "babel-jest": "^29.7.0",
-    "gh-pages": "^6.3.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1"

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-# Deploy only the freshly built static bundle; gh-pages owns publishing the
-# generated build directory to the repository's Pages branch.
+# Production deploys are owned by .github/workflows/deploy.yml when staging is
+# promoted to main. Keep this script as a local production-build validation
+# helper so maintainers do not publish from one machine.
 bash ./scripts/build-production.sh
-gh-pages -d build
+
+echo
+echo "Production build complete."
+echo "Merge staging into main to deploy through GitHub Actions."


### PR DESCRIPTION
## Summary
- add the workflow-run promotion path that opens and auto-merges dev -> staging after dev CI passes
- switch the deploy script to build-only so production deploys come from the GitHub Pages workflow
- document the resulting dev, staging, and main release path

## Why
GitHub Actions workflow_run triggers must exist on the repository default branch before they can react to dev CI completions. This PR seeds the orchestration change on main without promoting unrelated dev application changes to production.

## Validation
- bun run check
- bun run deploy
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/promote-dev-to-staging.yml"); puts "workflow yaml ok"'\n