### PR TITLE
Fix staging promotion workflow concurrency

### DIFF
--- a/.github/workflows/promote-dev-to-staging.yml
+++ b/.github/workflows/promote-dev-to-staging.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: promote-dev-to-staging
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   promote:


### PR DESCRIPTION
## Summary
- stop skipped workflow_run events from cancelling useful dev-push promotion runs
- keep the single promotion concurrency group, but queue instead of canceling in-flight runs

## Root cause
The promotion workflow receives workflow_run events for both push and pull_request CI runs. The job-level filter skips pull_request events, but workflow-level concurrency was cancelling the in-progress push promotion before that skipped run exited.

## Validation
- bun run check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/promote-dev-to-staging.yml"); puts "workflow yaml ok"'\n