### PR TITLE
Fix staging promotion workflow concurrency

### DIFF
--- a/.github/workflows/promote-dev-to-staging.yml
+++ b/.github/workflows/promote-dev-to-staging.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: promote-dev-to-staging
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   promote:


### PR DESCRIPTION
## Summary
- stop skipped workflow_run events from cancelling useful dev-push promotion runs
- keep the promotion workflow queued instead of cancelled when duplicate workflow_run events arrive

## Root cause
The promotion workflow receives workflow_run events for both push and pull_request CI. The pull_request run is skipped by the job filter, but the old workflow-level concurrency setting could cancel the in-progress push promotion first.

## Validation
- bun run check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/promote-dev-to-staging.yml"); puts "workflow yaml ok"'\n