### PR TITLE
Fix staging promotion workflow concurrency

### DIFF
--- a/.github/workflows/promote-dev-to-staging.yml
+++ b/.github/workflows/promote-dev-to-staging.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: promote-dev-to-staging
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   promote:


### PR DESCRIPTION
## Summary
- apply the promotion workflow concurrency fix to staging
- resolves the dev -> staging promotion conflict caused by staging missing the already-merged default-branch workflow fix

## Validation
- bun run check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/promote-dev-to-staging.yml"); puts "workflow yaml ok"'\n